### PR TITLE
Fix import of precice_config_graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 name = "precice-config-checker"
 version = "0.0.1"
 dependencies = [
-    "precice_config_graph @ https://git@github.com/precice-forschungsprojekt/config-graph",
+    "precice_config_graph @ git+https://github.com/precice-forschungsprojekt/config-graph.git",
     "pyprecice>=3.1.2",
 ]


### PR DESCRIPTION
The path for dependency import from GitHub was all wrong. This PR fixes that.