### PR TITLE
hotfix: changed imports and missing coupling

### DIFF
--- a/preciceconfigchecker/rules/example_1.py
+++ b/preciceconfigchecker/rules/example_1.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from ..rule import Rule
-from ..severity import Severity
-from ..violation import Violation
+from rule import Rule
+from severity import Severity
+from violation import Violation
 
 
 class Rule_1(Rule):

--- a/preciceconfigchecker/rules/example_2.py
+++ b/preciceconfigchecker/rules/example_2.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from ..rule import Rule
-from ..severity import Severity
-from ..violation import Violation
+from rule import Rule
+from severity import Severity
+from violation import Violation
 
 
 class Rule_2(Rule):

--- a/preciceconfigchecker/rules/example_3.py
+++ b/preciceconfigchecker/rules/example_3.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from ..rule import Rule
-from ..severity import Severity
-from ..violation import Violation
+from rule import Rule
+from severity import Severity
+from violation import Violation
 
 
 class Rule_3(Rule):

--- a/preciceconfigchecker/rules/missing_coupling.py
+++ b/preciceconfigchecker/rules/missing_coupling.py
@@ -3,10 +3,9 @@ from typing import List
 import networkx as nx
 from networkx import DiGraph
 from precice_config_graph.nodes import CouplingNode, MultiCouplingNode
-
-from ..rule import Rule
-from ..severity import Severity
-from ..violation import Violation
+from rule import Rule
+from severity import Severity
+from violation import Violation
 
 
 class MissingCouplingRule(Rule):
@@ -33,7 +32,7 @@ class MissingCouplingRule(Rule):
         multi_coupling_nodes = nx.subgraph_view(graph, filter_node=filter_multi_coupling_nodes)
 
         # If both subgraphs are empty, no coupling nodes exist
-        if nx.is_empty(coupling_nodes) and not nx.is_empty(multi_coupling_nodes):
+        if nx.is_empty(coupling_nodes) and nx.is_empty(multi_coupling_nodes):
             self.violations.append(self.MissingCouplingViolation())
 
 


### PR DESCRIPTION
Imports for project internal classes are now working, even though IntelliJ thinks they won't.

Also there was an error in how the missing coupling was tested.