### PR TITLE
Refactor how we import rules to make it easier to implement tests

### DIFF
--- a/preciceconfigchecker/cli.py
+++ b/preciceconfigchecker/cli.py
@@ -6,13 +6,8 @@ import color as c
 
 from precice_config_graph import graph, xml_processing
 
-from rule import check_all_rules, print_all_results
+from rules_processing import check_all_rules, print_all_results
 
-# ALL RULES THAT SHOULD BE CHECKED NEED TO BE IMPORTED
-# SOME IDE's MIGHT REMOVE THEM AS UNUSED IMPORTS
-from rules import missing_coupling
-from rules import missing_exchange
-from rules import data_use_read_write
 
 path: str = None
 debug: bool = False

--- a/preciceconfigchecker/rule.py
+++ b/preciceconfigchecker/rule.py
@@ -84,50 +84,6 @@ class Rule(ABC):
         if self.severity == Severity.ERROR:
             Rule.number_errors += len(self.violations)
 
-
 # To handle all the rules
-rules: List[Rule] = []
+rules: list[Rule] = []
 """List of all initialized rules. Info: Each rule puts itself on this list when initialized."""
-
-
-def all_rules_satisfied() -> bool:
-    """
-    Checks whether all rules are satisfied.
-
-    Returns:
-        bool: TRUE, if all rules are satisfied.
-    """
-    return all(rule.satisfied() for rule in rules)
-
-
-def check_all_rules(graph: Graph, debug: bool) -> None:
-
-    """
-    Checks all rules for violations
-    """
-    print("\nChecking rules...")
-    for rule in rules:
-        if debug or rule.severity != Severity.DEBUG:
-            rule.check(graph)
-    print("Rules checked.")
-
-
-def print_all_results(debug: bool) -> None:
-    """
-    Prints all existing violations of all rules
-    """
-    if not all_rules_satisfied():
-        print("The following issues were found:")
-    for rule in rules:
-        rule.print_result(debug)
-    error_str:str = f"{Severity.ERROR.value}"
-    warning_str:str = f"{Severity.WARNING.value}"
-    if Rule.number_errors != 1:
-        error_str += "s"
-    if Rule.number_warnings != 1:
-        warning_str += "s"
-    if Rule.number_errors != 0 or Rule.number_warnings != 0:
-        print(f"Your configuration file raised {Rule.number_errors} {error_str} and {Rule.number_warnings} {warning_str}.")
-        print("Please review your configuration file before continuing.")
-    else:
-        print("You are all set to start you simulation!")

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -1,0 +1,53 @@
+from networkx import Graph
+
+from preciceconfigchecker.rule import Rule, rules
+from preciceconfigchecker.severity import Severity
+
+# ALL RULES THAT SHOULD BE CHECKED NEED TO BE IMPORTED
+# SOME IDE's MIGHT REMOVE THEM AS UNUSED IMPORTS
+from rules import missing_coupling
+from rules import missing_exchange
+from rules import data_use_read_write
+
+
+def all_rules_satisfied() -> bool:
+    """
+    Checks whether all rules are satisfied.
+
+    Returns:
+        bool: TRUE, if all rules are satisfied.
+    """
+    return all(rule.satisfied() for rule in rules)
+
+
+def check_all_rules(graph: Graph, debug: bool) -> None:
+
+    """
+    Checks all rules for violations
+    """
+    print("\nChecking rules...")
+    for rule in rules:
+        if debug or rule.severity != Severity.DEBUG:
+            violations_for_this_rule = rule.check(graph)
+    print("Rules checked.")
+
+
+def print_all_results(debug: bool) -> None:
+    """
+    Prints all existing violations of all rules
+    """
+    if not all_rules_satisfied():
+        print("The following issues were found:")
+    for rule in rules:
+        rule.print_result(debug)
+    error_str:str = f"{Severity.ERROR.value}"
+    warning_str:str = f"{Severity.WARNING.value}"
+    if Rule.number_errors != 1:
+        error_str += "s"
+    if Rule.number_warnings != 1:
+        warning_str += "s"
+    if Rule.number_errors != 0 or Rule.number_warnings != 0:
+        print(f"Your configuration file raised {Rule.number_errors} {error_str} and {Rule.number_warnings} {warning_str}.")
+        print("Please review your configuration file before continuing.")
+    else:
+        print("You are all set to start you simulation!")


### PR DESCRIPTION
Moves import of all rules into a separate file `rules_processing.py`. This can then be imported by tests, eliminating the need for importing all rules manually.