### PR TITLE
Refactor rules to return violations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,10 +9,10 @@ This program is designed to collect all messages, and then, after having checked
 - potential use as a library
 - merging multiple related messages into one
 
-The actual logic for checking for Violations is implemented in Rules. A Rule is a class with a `check` method, that takes in the graph built from the config file and stores zero or more Violations. Each Violation refers to one (potential) error. Since one Rule can be violated multiple times, Rules and Violations have a `1:N` relation.
+The actual logic for checking for Violations is implemented in Rules. A Rule is a class with a `check` method, that takes in the graph built from the config file and returns zero or more Violations. Each Violation refers to one (potential) error. Since one Rule can be violated multiple times, Rules and Violations have a `1:N` relation.
 
 ### Mixed Violations
 
 Sometimes, rules can be summarized. Take as an example the `<data />` node. It can be read, but never written to. It can also be written to, but never read. Additionally, it can never be written or read. In the latter case, it would be confusing to print two errors ("this data is never written to" and "this data is never read").
 
-Therefore, some Rules have mixed Violation types. For our example, this means the `DataUseReadWrite`-Rule produces Violations that are of different types (`DataNotUsedNotReadNotWrittenViolation`, `DataUsedNotReadNotWrittenViolation`, etc.).
+Therefore, some Rules can return mixed Violation types. For our example, this means the `DataUseReadWrite`-Rule produces Violations that are of different types (`DataNotUsedNotReadNotWrittenViolation`, `DataUsedNotReadNotWrittenViolation`, etc.).

--- a/preciceconfigchecker/cli.py
+++ b/preciceconfigchecker/cli.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     graph = graph.get_graph(root)
 
     # Individual checks need the graph
-    check_all_rules(graph, debug)
+    violations_by_rule = check_all_rules(graph, debug)
 
     # if the user uses severity=debug, then the severity has to be passed here as an argument
-    print_all_results(debug)
+    print_all_results(violations_by_rule, debug)

--- a/preciceconfigchecker/rule.py
+++ b/preciceconfigchecker/rule.py
@@ -1,22 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import List
 
 from networkx import Graph
 
 from severity import Severity
 from violation import Violation
-import color as c
 
 
 class Rule(ABC):
     """
     Abstract Class 'Rule'. Checking a 'Rule' for violations and producing formatted output.
     """
-
-    number_errors: int = 0
-    """Static Attribute: Do not use 'self.number_errors', use 'Rule.number_errors'"""
-    number_warnings: int = 0
-    """Static Attribute: Do not use 'self.number_warnings', use 'Rule.number_warnings'"""
 
     @property
     @abstractmethod
@@ -34,55 +27,16 @@ class Rule(ABC):
         """
         Initializes a Rule object.
         """
-        self.violations: List[Violation] = []
         rules.append(self)
 
     @abstractmethod
-    def check(self, graph: Graph) -> None:
+    def check(self, graph: Graph) -> list[Violation]:
         """
         @abstractmethod: Defines how a 'Rule' should be checked
 
-        Hint: Use 'self.violations.append(self.MyViolation(...))' to save the results directly. MyViolation should be an inner class of type Violation.
+        Hint: Implement Violations as inner classes in the rule of type Violation.
         """
         pass
-
-    def satisfied(self) -> bool:
-        """
-        Shows when the 'Rule' is satisfied
-
-        Returns:
-            bool: TRUE, if there are no violations after the check
-        """
-        return self.violations.__len__() == 0
-
-    def print_result(self, debug: bool) -> None:
-        """
-        If the 'Rule' has violations, these will be printed.
-        If debug mode is enabled, more information is displayed.
-        """
-        if not debug and (self.severity == Severity.DEBUG or self.satisfied()):
-            return
-        if self.satisfied():
-            print(f"[{Severity.DEBUG.value}]: '{c.dyeing(self.__class__.__name__, c.purple)}' is satisfied.")
-            return
-
-        severity_info: str
-        if debug and self.severity != Severity.DEBUG:
-            severity_info = f"[{self.severity.value},{Severity.DEBUG.value}]: ({c.dyeing(self.__class__.__name__, c.purple)})"
-        elif debug and self.severity == Severity.DEBUG:
-            severity_info = f"[{Severity.DEBUG.value}]: ({c.dyeing(self.__class__.__name__, c.purple)})"
-        else:
-            severity_info = f"[{self.severity.value}]:"
-        print(f"{severity_info} {self.name}")
-
-        for violation in self.violations:
-            formatted_violation = violation.format()
-            print(formatted_violation)
-
-        if self.severity == Severity.WARNING:
-            Rule.number_warnings += len(self.violations)
-        if self.severity == Severity.ERROR:
-            Rule.number_errors += len(self.violations)
 
 
 # To handle all the rules

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -101,7 +101,9 @@ class DataUseReadWrite(Rule):
             return [f"Consider having a participant write {self.data_node.name}.",
                     "Otherwise please remove it to improve readability."]
 
-    def check(self, graph: Graph) -> None:
+    def check(self, graph: Graph) -> list[Violation]:
+        violations: list[Violation] = []
+
         g1 = nx.subgraph_view(graph, filter_node=filter_use_read_write_data)
         for node in g1.nodes:
             # We only need to test data nodes here
@@ -148,11 +150,11 @@ class DataUseReadWrite(Rule):
                     # Everything is fine here
                     continue
                 elif use_data and read_data and not write_data:
-                    self.violations.append(self.DataUsedReadNotWrittenViolation(node, mesh, reader))
+                    violations.append(self.DataUsedReadNotWrittenViolation(node, mesh, reader))
                 elif use_data and not read_data and write_data:
-                    self.violations.append(self.DataUsedNotReadWrittenViolation(node, mesh, writer))
+                    violations.append(self.DataUsedNotReadWrittenViolation(node, mesh, writer))
                 elif use_data and not read_data and not write_data:
-                    self.violations.append(self.DataUsedNotReadNotWrittenViolation(node, mesh))
+                    violations.append(self.DataUsedNotReadNotWrittenViolation(node, mesh))
                 elif not use_data and read_data and write_data:
                     # This case gets handled by precice-tools check
                     continue
@@ -163,7 +165,9 @@ class DataUseReadWrite(Rule):
                     # This case gets handled by precice-tools check
                     continue
                 elif not use_data and not read_data and not write_data:
-                    self.violations.append(self.DataNotUsedNotReadNotWrittenViolation(node))
+                    violations.append(self.DataNotUsedNotReadNotWrittenViolation(node))
+
+        return violations
 
 
 # Initialize a rule object to add it to the rules-array.

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import networkx as nx
 from networkx import Graph
 from precice_config_graph.nodes import DataNode, MeshNode, ReadDataNode, WriteDataNode, WatchPointNode, ExportNode, \
@@ -25,7 +23,7 @@ class DataUseReadWrite(Rule):
         def format_explanation(self) -> str:
             return f"Data {self.data_node.name} is declared but never used, read or written."
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Consider using {self.data_node.name} in a mesh and have participants read and write it.",
                     "Otherwise please remove it to improve readability."]
 
@@ -41,7 +39,7 @@ class DataUseReadWrite(Rule):
         def format_explanation(self) -> str:
             return f"Data {self.data_node.name} gets used in mesh {self.mesh.name}, but nobody is reading or writing it."
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant read data {self.data_node.name}.",
                     f"Consider having a participant write data {self.data_node.name}.",
                     "Otherwise please remove it to improve readability."]
@@ -61,7 +59,7 @@ class DataUseReadWrite(Rule):
                 f"Data {self.data_node.name} is used in mesh {self.mesh.name} and participant {self.participant.name} "
                 f"is writing it, but nobody is reading it.")
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant read data {self.data_node.name}.",
                     f"Consider exporting data {self.data_node.name} by a participant.",
                     f"Consider using watchpoints or watch-integrals to keep track of data {self.data_node.name}.",
@@ -97,7 +95,7 @@ class DataUseReadWrite(Rule):
                 f"Data {self.data_node.name} is being used in mesh {self.mesh.name} and {self.type} {self.name} "
                 f"is reading it, but nobody is writing it.")
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant write {self.data_node.name}.",
                     "Otherwise please remove it to improve readability."]
 

--- a/preciceconfigchecker/rules/examples/example_1.py
+++ b/preciceconfigchecker/rules/examples/example_1.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rule import Rule
 from severity import Severity
 from violation import Violation
@@ -15,7 +13,7 @@ class Rule_1(Rule):
         def format_explanation(self) -> str:
             return f"Something went wrong between {self.node_a} and {self.node_b}"
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Delete {self.node_a}",
                     f"Delete {self.node_b}",
                     f"Connect {self.node_a} and {self.node_b}"
@@ -24,11 +22,16 @@ class Rule_1(Rule):
     severity = Severity.WARNING
     name = "1st Example Rule"
 
-    def check(self, graph) -> None:
-        #Find violations in the graph and add them to the violations list in Rule.
-        self.violations.append(self.MyViolation("Node-A", "Node-B", 1))
-        self.violations.append(self.MyViolation("Node-C", "Node-D", 2))
-        self.violations.append(self.MyViolation("Node-E", "Node-F", 3))
+    def check(self, graph) -> list[Violation]:
+        #Find violations in the graph and return them.
+        violations = [
+            self.MyViolation("Node-A", "Node-B", 1)
+        ]
+        # ...
+        violations.append(self.MyViolation("Node-C", "Node-D", 2))
+        # ...
+        violations.append(self.MyViolation("Node-E", "Node-F", 3))
+        return violations
 
 
 Rule_1()

--- a/preciceconfigchecker/rules/examples/example_2.py
+++ b/preciceconfigchecker/rules/examples/example_2.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rule import Rule
 from severity import Severity
 from violation import Violation
@@ -16,7 +14,7 @@ class Rule_2(Rule):
         def format_explanation(self) -> str:
             return f"Something went wrong between {self.node_a}, {self.node_b} and {self.node_c}"
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Delete {self.node_a}",
                     f"Delete {self.node_b}",
                     f"Delete {self.node_c}",
@@ -28,9 +26,9 @@ class Rule_2(Rule):
     severity = Severity.WARNING
     name = "2nd Example Rule"
 
-    def check(self, graph) -> None:
-        # Find violations in the graph and add them to the violations list in Rule.
-        self.violations.append(self.MyViolation("Node-G", "Node-H", "Node-I"))
+    def check(self, graph) -> list[Violation]:
+        #Find violations in the graph and return them.
+        return [ self.MyViolation("Node-G", "Node-H", "Node-I") ]
 
 
 Rule_2()

--- a/preciceconfigchecker/rules/examples/example_3.py
+++ b/preciceconfigchecker/rules/examples/example_3.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rule import Rule
 from severity import Severity
 from violation import Violation
@@ -13,15 +11,15 @@ class Rule_3(Rule):
         def format_explanation(self) -> str:
             return f"Something went wrong with {self.node_a}"
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Delete {self.node_a}"]
 
     severity = Severity.ERROR
     name = "3rd Example Rule"
 
-    def check(self, graph) -> None:
-        # Find violations in the graph and add them to the violations list in Rule.
-        self.violations.append(self.MyViolation("Node-M"))
+    def check(self, graph) -> list[Violation]:
+        #Find violations in the graph and return them.
+        return [ self.MyViolation("Node-M") ]
 
 
 Rule_3()

--- a/preciceconfigchecker/rules/examples/example_4.py
+++ b/preciceconfigchecker/rules/examples/example_4.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rule import Rule
 from severity import Severity
 from violation import Violation
@@ -12,15 +10,15 @@ class Rule_4(Rule):
         def format_explanation(self) -> str:
             return f"Something went wrong with {self.node_a}"
         
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Delete {self.node_a}"
             ]
 
     severity = Severity.ERROR
     name = "4th Example Rule"
 
-    def check(self, graph) -> None:
-        #Find violations in the graph and add them to the violations list in Rule.
-        pass
+    def check(self, graph) -> list[Violation]:
+        #Find violations in the graph and return them.
+        return []
     
 Rule_4()

--- a/preciceconfigchecker/rules/examples/example_5.py
+++ b/preciceconfigchecker/rules/examples/example_5.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rule import Rule
 from severity import Severity
 from violation import Violation
@@ -12,7 +10,7 @@ class Rule_5(Rule):
         def format_explanation(self) -> str:
             return "Testing Debug"
         
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return ["The",
                     "Test"
             ]
@@ -20,8 +18,8 @@ class Rule_5(Rule):
     severity = Severity.DEBUG
     name = "5th Example Rule"
 
-    def check(self, graph) -> None:
-        #Find violations in the graph and add them to the violations list in Rule.
-        self.violations.append(self.MyViolation(42))
+    def check(self, graph) -> list[Violation]:
+        #Find violations in the graph and return them.
+        return [ self.MyViolation(42) ]
     
 Rule_5()

--- a/preciceconfigchecker/rules/missing_coupling.py
+++ b/preciceconfigchecker/rules/missing_coupling.py
@@ -27,7 +27,7 @@ class MissingCouplingSchemeRule(Rule):
         def format_possible_solutions(self) -> List[str]:
             return ["Please add a coupling-scheme to your configuration to exchange data between participants."]
 
-    def check(self, graph: Graph) -> None:
+    def check(self, graph: Graph) -> list[MissingCouplingSchemeViolation]:
         # Filter all coupling-nodes: Only coupling-scheme nodes remain
         coupling_nodes = nx.subgraph_view(graph, filter_node=filter_coupling_scheme_nodes)
         # Filter all multi-coupling-nodes: Only multi-coupling-scheme nodes remain
@@ -35,7 +35,9 @@ class MissingCouplingSchemeRule(Rule):
 
         # If both subgraphs contain no nodes, no coupling nodes exist
         if not coupling_nodes.nodes and not multi_coupling_nodes.nodes:
-            self.violations.append(self.MissingCouplingSchemeViolation())
+            return [self.MissingCouplingSchemeViolation()]
+
+        return []
 
 
 # Initialize a rule object to add it to the rules-array.

--- a/preciceconfigchecker/rules/missing_coupling.py
+++ b/preciceconfigchecker/rules/missing_coupling.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import networkx as nx
 from networkx import Graph
 from precice_config_graph.nodes import CouplingSchemeNode, MultiCouplingSchemeNode
@@ -24,7 +22,7 @@ class MissingCouplingSchemeRule(Rule):
         def format_explanation(self) -> str:
             return "It seems like your configuration is missing a coupling-scheme."
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return ["Please add a coupling-scheme to your configuration to exchange data between participants."]
 
     def check(self, graph: Graph) -> list[MissingCouplingSchemeViolation]:

--- a/preciceconfigchecker/rules/missing_exchange.py
+++ b/preciceconfigchecker/rules/missing_exchange.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import networkx as nx
 from networkx import Graph
 from precice_config_graph.nodes import DataNode, ExchangeNode, MeshNode, ParticipantNode, ReadDataNode, WriteDataNode
@@ -25,7 +23,7 @@ class MissingExchangeRule(Rule):
         def format_explanation(self) -> str:
             return f"Data {self.data_node.name} does not get exchanged in a coupling-scheme."
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Please exchange {self.data_node.name} in a coupling-scheme.",
                     "Otherwise, please remove it to improve readability."]
 
@@ -45,7 +43,7 @@ class MissingExchangeRule(Rule):
             return (f"Data {self.data_node.name} is used in mesh {self.mesh.name}, gets written by participant {self.writer.name} "
                     f"and read by participant {self.reader.name}, but does not get exchanged in a coupling-scheme.")
 
-        def format_possible_solutions(self) -> List[str]:
+        def format_possible_solutions(self) -> list[str]:
             return [f"Please exchange {self.data_node.name} in a coupling-scheme.",
                     f"Simply add the following line to a coupling-scheme involving participants {self.reader.name} and "
                     f"{self.writer.name}:\n "

--- a/preciceconfigchecker/rules/missing_exchange.py
+++ b/preciceconfigchecker/rules/missing_exchange.py
@@ -51,9 +51,11 @@ class MissingExchangeRule(Rule):
                     f"{self.writer.name}:\n "
                     f"<exchange data=\"{self.data_node.name}\" mesh=\"{self.mesh.name}\" from=\"{self.writer.name}\" to=\"{self.reader.name}\" />"]
 
-    def check(self, graph: Graph) -> None:
+    def check(self, graph: Graph) -> list[Violation]:
         # Only data and exchange nodes remain
         g1 = nx.subgraph_view(graph, filter_node=filter_data_exchange_nodes)
+
+        violations = []
 
         for node in g1.nodes():
             # Check all data nodes
@@ -75,10 +77,12 @@ class MissingExchangeRule(Rule):
                             writer = adjacent.participant
                     # Data gets used, read and written
                     if mesh and reader and writer:
-                        self.violations.append(self.MissingUseDataExchangeViolation(node, mesh, reader, writer))
+                        violations.append(self.MissingUseDataExchangeViolation(node, mesh, reader, writer))
                     # Data does not get used, read and written
                     else:
-                        self.violations.append(self.MissingExchangeViolation(node))
+                        violations.append(self.MissingExchangeViolation(node))
+
+        return violations
 
 
 # Initialize a rule object to add it to the rules-array.

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -1,53 +1,87 @@
 from networkx import Graph
 
+from preciceconfigchecker.violation import Violation
 from rule import Rule, rules
 from severity import Severity
+import color as c
 
 # ALL RULES THAT SHOULD BE CHECKED NEED TO BE IMPORTED
 # SOME IDE's MIGHT REMOVE THEM AS UNUSED IMPORTS
-from rules import missing_coupling
-from rules import missing_exchange
-from rules import data_use_read_write
+# noinspection PyUnresolvedReferences
+from rules import missing_coupling, missing_exchange, data_use_read_write
 
 
-def all_rules_satisfied() -> bool:
+def all_rules_satisfied(violations_by_rule: dict[Rule, list[Violation]]) -> bool:
     """
     Checks whether all rules are satisfied.
 
     Returns:
-        bool: TRUE, if all rules are satisfied.
+        bool: True, if all rules are satisfied.
     """
-    return all(rule.satisfied() for rule in rules)
+    return all(len(violations) == 0 for violations in violations_by_rule.values())
 
 
-def check_all_rules(graph: Graph, debug: bool) -> None:
+def check_all_rules(graph: Graph, debug: bool) -> dict[Rule, list[Violation]]:
     """
     Checks all rules for violations
     """
     print("\nChecking rules...")
+
+    violations_by_rule = {}
+
     for rule in rules:
         if debug or rule.severity != Severity.DEBUG:
-            rule.check(graph)
+            violations_by_rule[rule] = rule.check(graph)
+
     print("Rules checked.")
+    return violations_by_rule
 
 
-def print_all_results(debug: bool) -> None:
+def print_all_results(violations_by_rule: dict[Rule, list[Violation]], debug: bool):
     """
     Prints all existing violations of all rules
     """
-    if not all_rules_satisfied():
+    if not all_rules_satisfied(violations_by_rule):
         print("The following issues were found:")
-    for rule in rules:
-        rule.print_result(debug)
-    error_str: str = f"{Severity.ERROR.value}"
-    warning_str: str = f"{Severity.WARNING.value}"
-    if Rule.number_errors != 1:
-        error_str += "s"
-    if Rule.number_warnings != 1:
-        warning_str += "s"
-    if Rule.number_errors != 0 or Rule.number_warnings != 0:
-        print(f"Your configuration file raised {Rule.number_errors} {error_str} "
-              f"and {Rule.number_warnings} {warning_str}.")
+    for (rule, violations) in violations_by_rule.items():
+        print_result(rule, violations, debug)
+
+    def total_violations_by_severity(severity: Severity) -> int:
+        return sum(len(violations) for (rule, violations) in violations_by_rule.items() if rule.severity == severity)
+
+    total_num_errors = total_violations_by_severity(Severity.ERROR)
+    total_num_warnings = total_violations_by_severity(Severity.WARNING)
+
+    if total_num_errors != 0 or total_num_warnings != 0:
+        error_str: str = Severity.ERROR.value + ("s" if total_num_errors != 1 else "")
+        warning_str: str = Severity.WARNING.value + ("s" if total_num_errors != 1 else "")
+        print(f"Your configuration file raised {total_num_errors} {error_str} "
+              f"and {total_num_warnings} {warning_str}.")
         print("Please review your configuration file before continuing.")
     else:
         print("You are all set to start you simulation!")
+
+
+def print_result(rule: Rule, violations: list[Violation], debug: bool):
+    """
+    If the rule has violations, these will be printed.
+    If debug mode is enabled, more information is displayed.
+    """
+    if not debug and (rule.severity == Severity.DEBUG or len(violations) == 0):
+        return
+    if len(violations) == 0:
+        print(f"[{Severity.DEBUG.value}]: '{c.dyeing(rule.__class__.__name__, c.purple)}' is satisfied.")
+        return
+
+    severity_info: str
+    if debug and rule.severity != Severity.DEBUG:
+        severity_info = f"[{rule.severity.value},{Severity.DEBUG.value}]: ({c.dyeing(rule.__class__.__name__, c.purple)})"
+    elif debug and rule.severity == Severity.DEBUG:
+        severity_info = f"[{Severity.DEBUG.value}]: ({c.dyeing(rule.__class__.__name__, c.purple)})"
+    else:
+        severity_info = f"[{rule.severity.value}]:"
+    print(f"{severity_info} {rule.name}")
+
+    for violation in violations:
+        formatted_violation = violation.format()
+        print(formatted_violation)


### PR DESCRIPTION
# Current Situation

When calling `check` on a rule, violations are added to an array inside of the rule itself

# Problems

- When using the API wrong, you could call `check` twice and get duplicated violations
- When executing tests, the violations array is not emptied between runs. This makes tests unnecessarily hard, because you'd have to remember to clean the violations array (not good API design).

# Proposed Solution

Return the violations instead of storing them in the rule and let the caller handle the rest.

---

Should be merged before #49 