### PR TITLE
rules initialized in rules_processing

### DIFF
--- a/preciceconfigchecker/rule.py
+++ b/preciceconfigchecker/rule.py
@@ -27,7 +27,6 @@ class Rule(ABC):
         """
         Initializes a Rule object.
         """
-        rules.append(self)
 
     @abstractmethod
     def check(self, graph: Graph) -> list[Violation]:
@@ -37,8 +36,3 @@ class Rule(ABC):
         Hint: Implement Violations as inner classes in the rule of type Violation.
         """
         pass
-
-
-# To handle all the rules
-rules: list[Rule] = []
-"""List of all initialized rules. Info: Each rule puts itself on this list when initialized."""

--- a/preciceconfigchecker/rules/compositional_coupling.py
+++ b/preciceconfigchecker/rules/compositional_coupling.py
@@ -59,9 +59,6 @@ class CompositionalCouplingRule(Rule):
         return violations
 
 
-CompositionalCouplingRule()
-
-
 # Helper functions
 def filter_coupling_scheme_nodes(node) -> bool:
     """

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -218,10 +218,6 @@ class DataUseReadWriteRule(Rule):
         return violations
 
 
-# Initialize a rule object to add it to the rules-array.
-DataUseReadWriteRule()
-
-
 def filter_use_read_write_data(node) -> bool:
     """
     This method filters nodes, that could potentially use data, read data or write data.

--- a/preciceconfigchecker/rules/missing_coupling.py
+++ b/preciceconfigchecker/rules/missing_coupling.py
@@ -38,10 +38,6 @@ class MissingCouplingSchemeRule(Rule):
         return []
 
 
-# Initialize a rule object to add it to the rules-array.
-MissingCouplingSchemeRule()
-
-
 # Helper functions
 def filter_coupling_scheme_nodes(node) -> bool:
     """

--- a/preciceconfigchecker/rules/missing_exchange.py
+++ b/preciceconfigchecker/rules/missing_exchange.py
@@ -46,10 +46,6 @@ class MissingExchangeRule(Rule):
         return violations
 
 
-# Initialize a rule object to add it to the rules-array.
-MissingExchangeRule()
-
-
 # Helper functions
 def filter_exchange_coupling_scheme_nodes(node) -> bool:
     """

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -1,13 +1,19 @@
 from networkx import Graph
 
 import preciceconfigchecker.color as c
-from preciceconfigchecker.rule import Rule, rules
+from preciceconfigchecker.rule import Rule
 # ALL RULES THAT SHOULD BE CHECKED NEED TO BE IMPORTED
 # SOME IDE's MIGHT REMOVE THEM AS UNUSED IMPORTS
 # noinspection PyUnresolvedReferences
 from preciceconfigchecker.rules import missing_coupling, missing_exchange, data_use_read_write, compositional_coupling
 from preciceconfigchecker.severity import Severity
 from preciceconfigchecker.violation import Violation
+
+rules:list[Rule] = [missing_coupling.MissingCouplingSchemeRule(),
+                    missing_exchange.MissingExchangeRule(),
+                    data_use_read_write.DataUseReadWriteRule(),
+                    compositional_coupling.CompositionalCouplingRule()
+                    ]
 
 
 def all_rules_satisfied(violations_by_rule: dict[Rule, list[Violation]]) -> bool:


### PR DESCRIPTION
The list of `rules` has been removed from `rule.py` and added to `rules_processing.py`. Imports have been adjusted. Each rule no longer adds itself to a list upon initialization. Each rule is now initialized in `rules_processing.py` and added to the list of `rules`.