### PR TITLE
Changing the rules

### DIFF
--- a/preciceconfigchecker/rule.py
+++ b/preciceconfigchecker/rule.py
@@ -27,7 +27,6 @@ class Rule(ABC):
         """
         Initializes a Rule object.
         """
-        rules.append(self)
 
     @abstractmethod
     def check(self, graph: Graph) -> list[Violation]:
@@ -37,8 +36,3 @@ class Rule(ABC):
         Hint: Implement Violations as inner classes in the rule of type Violation.
         """
         pass
-
-
-# To handle all the rules
-rules: list[Rule] = []
-"""List of all initialized rules. Info: Each rule puts itself on this list when initialized."""

--- a/preciceconfigchecker/rules/compositional_coupling.py
+++ b/preciceconfigchecker/rules/compositional_coupling.py
@@ -59,9 +59,6 @@ class CompositionalCouplingRule(Rule):
         return violations
 
 
-CompositionalCouplingRule()
-
-
 # Helper functions
 def filter_coupling_scheme_nodes(node) -> bool:
     """

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -218,10 +218,6 @@ class DataUseReadWriteRule(Rule):
         return violations
 
 
-# Initialize a rule object to add it to the rules-array.
-DataUseReadWriteRule()
-
-
 def filter_use_read_write_data(node) -> bool:
     """
     This method filters nodes, that could potentially use data, read data or write data.

--- a/preciceconfigchecker/rules/examples/example_1.py
+++ b/preciceconfigchecker/rules/examples/example_1.py
@@ -32,6 +32,3 @@ class Rule_1(Rule):
         # ...
         violations.append(self.MyViolation("Node-E", "Node-F", 3))
         return violations
-
-
-Rule_1()

--- a/preciceconfigchecker/rules/examples/example_2.py
+++ b/preciceconfigchecker/rules/examples/example_2.py
@@ -29,6 +29,3 @@ class Rule_2(Rule):
     def check(self, graph) -> list[Violation]:
         #Find violations in the graph and return them.
         return [ self.MyViolation("Node-G", "Node-H", "Node-I") ]
-
-
-Rule_2()

--- a/preciceconfigchecker/rules/examples/example_3.py
+++ b/preciceconfigchecker/rules/examples/example_3.py
@@ -20,6 +20,3 @@ class Rule_3(Rule):
     def check(self, graph) -> list[Violation]:
         #Find violations in the graph and return them.
         return [ self.MyViolation("Node-M") ]
-
-
-Rule_3()

--- a/preciceconfigchecker/rules/examples/example_4.py
+++ b/preciceconfigchecker/rules/examples/example_4.py
@@ -20,5 +20,3 @@ class Rule_4(Rule):
     def check(self, graph) -> list[Violation]:
         #Find violations in the graph and return them.
         return []
-    
-Rule_4()

--- a/preciceconfigchecker/rules/examples/example_5.py
+++ b/preciceconfigchecker/rules/examples/example_5.py
@@ -21,5 +21,3 @@ class Rule_5(Rule):
     def check(self, graph) -> list[Violation]:
         #Find violations in the graph and return them.
         return [ self.MyViolation(42) ]
-    
-Rule_5()

--- a/preciceconfigchecker/rules/m2n_exchange.py
+++ b/preciceconfigchecker/rules/m2n_exchange.py
@@ -107,6 +107,3 @@ class M2NExchangeRule(Rule):
                 elif violation.participant1 == participant2 and violation.participant2 == participant1:
                     return True
         return False
-
-
-M2NExchangeRule()

--- a/preciceconfigchecker/rules/missing_coupling.py
+++ b/preciceconfigchecker/rules/missing_coupling.py
@@ -38,10 +38,6 @@ class MissingCouplingSchemeRule(Rule):
         return []
 
 
-# Initialize a rule object to add it to the rules-array.
-MissingCouplingSchemeRule()
-
-
 # Helper functions
 def filter_coupling_scheme_nodes(node) -> bool:
     """

--- a/preciceconfigchecker/rules/missing_exchange.py
+++ b/preciceconfigchecker/rules/missing_exchange.py
@@ -46,10 +46,6 @@ class MissingExchangeRule(Rule):
         return violations
 
 
-# Initialize a rule object to add it to the rules-array.
-MissingExchangeRule()
-
-
 # Helper functions
 def filter_exchange_coupling_scheme_nodes(node) -> bool:
     """

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -1,7 +1,7 @@
 from networkx import Graph
 
 import preciceconfigchecker.color as c
-from preciceconfigchecker.rule import Rule, rules
+from preciceconfigchecker.rule import Rule
 # ALL RULES THAT SHOULD BE CHECKED NEED TO BE IMPORTED
 # SOME IDE's MIGHT REMOVE THEM AS UNUSED IMPORTS
 # noinspection PyUnresolvedReferences
@@ -9,6 +9,12 @@ from preciceconfigchecker.rules import missing_coupling, missing_exchange, data_
     m2n_exchange
 from preciceconfigchecker.severity import Severity
 from preciceconfigchecker.violation import Violation
+
+rules:list[Rule] = [missing_coupling.MissingCouplingSchemeRule(),
+                    missing_exchange.MissingExchangeRule(),
+                    data_use_read_write.DataUseReadWriteRule(),
+                    compositional_coupling.CompositionalCouplingRule()
+                    ]
 
 
 def all_rules_satisfied(violations_by_rule: dict[Rule, list[Violation]]) -> bool:

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -10,12 +10,13 @@ from preciceconfigchecker.rules import missing_coupling, missing_exchange, data_
 from preciceconfigchecker.severity import Severity
 from preciceconfigchecker.violation import Violation
 
-rules:list[Rule] = [missing_coupling.MissingCouplingSchemeRule(),
-                    missing_exchange.MissingExchangeRule(),
-                    data_use_read_write.DataUseReadWriteRule(),
-                    compositional_coupling.CompositionalCouplingRule(),
-                    m2n_exchange.M2NExchangeRule()
-                    ]
+rules:list[Rule] = [
+    missing_coupling.MissingCouplingSchemeRule(),
+    missing_exchange.MissingExchangeRule(),
+    data_use_read_write.DataUseReadWriteRule(),
+    compositional_coupling.CompositionalCouplingRule(),
+    m2n_exchange.M2NExchangeRule()
+]
 
 
 def all_rules_satisfied(violations_by_rule: dict[Rule, list[Violation]]) -> bool:

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -13,7 +13,8 @@ from preciceconfigchecker.violation import Violation
 rules:list[Rule] = [missing_coupling.MissingCouplingSchemeRule(),
                     missing_exchange.MissingExchangeRule(),
                     data_use_read_write.DataUseReadWriteRule(),
-                    compositional_coupling.CompositionalCouplingRule()
+                    compositional_coupling.CompositionalCouplingRule(),
+                    m2n_exchange.M2NExchangeRule()
                     ]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,7 @@ import io
 from networkx import Graph
 from precice_config_graph import xml_processing, graph as g
 
-from preciceconfigchecker.rule import rules
-from preciceconfigchecker.rules_processing import check_all_rules
+from preciceconfigchecker.rules_processing import rules, check_all_rules
 from preciceconfigchecker.violation import Violation
 from preciceconfigchecker import color
 


### PR DESCRIPTION
The list of `rules` has been removed from `rule.py` and added to `rules_processing.py`. Imports have been adjusted. Each `rule` no longer adds itself to a list upon initialization. Each `rule` is now initialized in `rules_processing.py` and added to the list of `rules`.