### PR TITLE
Make data not exchanged violation smarter, fix m2n rule and improve test utils

### DIFF
--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -175,14 +175,16 @@ class DataUseReadWriteRule(Rule):
                     # Check if data gets read and written by the same participant.
                     # If so, then no exchange is needed.
                     # Otherwise, an exchange is needed.
-                    for writer in writers:
-                        for reader in readers:
+                    writer_s = set(writers)
+                    reader_s = set(readers)
+                    for writer in writer_s:
+                        for reader in reader_s:
                             # If they are the same, then everything is fine.
                             if reader == writer:
                                 continue
                             # Otherwise, there needs to be an exchange of data between them.
                             else:
-                                if writer not in data_flow_graph or reader not in data_flow_graph:
+                                if writer not in data_flow_graph.nodes or reader not in data_flow_graph.nodes:
                                     # One of writer/reader is not connected through an exchange involving data_node
                                     violations.append(self.DataNotExchangedViolation(data_node, writer, reader))
                                 else:

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -1,7 +1,7 @@
 import networkx as nx
 from networkx import Graph
 from precice_config_graph.nodes import DataNode, MeshNode, ReadDataNode, WriteDataNode, WatchPointNode, ExportNode, \
-    WatchIntegralNode, ParticipantNode, ExchangeNode, ActionNode
+    WatchIntegralNode, ParticipantNode, ExchangeNode, ActionNode, ReceiveMeshNode
 from preciceconfigchecker.rule import Rule
 from preciceconfigchecker.severity import Severity
 from preciceconfigchecker.violation import Violation
@@ -104,7 +104,6 @@ class DataUseReadWriteRule(Rule):
 
     def check(self, graph: Graph) -> list[Violation]:
         violations: list[Violation] = []
-
         g1 = nx.subgraph_view(graph, filter_node=filter_use_read_write_data)
         for data_node in g1.nodes:
             # We only need to test data nodes here
@@ -115,6 +114,7 @@ class DataUseReadWriteRule(Rule):
                 meshes: list[MeshNode] = []
                 writers: list[ParticipantNode] = []
                 readers: list[ParticipantNode] = []
+                readers_per_writer: map[ParticipantNode: list[ParticipantNode]] = {}
 
                 # Check all neighbors of the data node for use-, reader- and writer-nodes
                 for neighbor in g1.neighbors(data_node):
@@ -126,16 +126,14 @@ class DataUseReadWriteRule(Rule):
                         # Check if mesh gets observed by export, action, watchpoint or watch-integral.
                         # These types of reader nodes do not read the data itself, but only "read" the mesh and all of
                         # its used data.
-                        # They are thus less important than a read-data node (which represents a participant),
-                        # so only check them if no read-data node has been found.
                         for mesh_neighbor in mesh_neighbors:
-                            if isinstance(mesh_neighbor, ExportNode) and not read_data:
+                            if isinstance(mesh_neighbor, ExportNode):
                                 read_data = True
                                 readers += [mesh_neighbor.participant]
-                            elif isinstance(mesh_neighbor, WatchPointNode) and not read_data:
+                            elif isinstance(mesh_neighbor, WatchPointNode):
                                 read_data = True
                                 readers += [mesh_neighbor.participant]
-                            elif isinstance(mesh_neighbor, WatchIntegralNode) and not read_data:
+                            elif isinstance(mesh_neighbor, WatchIntegralNode):
                                 read_data = True
                                 readers += [mesh_neighbor.participant]
                             elif isinstance(mesh_neighbor, ActionNode):
@@ -152,7 +150,8 @@ class DataUseReadWriteRule(Rule):
                                     # Use the participant associated with the action
                                     writers += [mesh_neighbor.participant]
 
-                    # Check if data gets read by a participant
+                    # Check if data gets read by a participant.
+                    # Only read-data nodes reading current data_node are connected to it
                     elif isinstance(neighbor, ReadDataNode):
                         read_data = True
                         readers += [neighbor.participant]
@@ -161,9 +160,57 @@ class DataUseReadWriteRule(Rule):
                         write_data = True
                         writers += [neighbor.participant]
 
+                # For every writer, identify the corresponding set of readers
+                for writer in writers:
+                    readers_per_writer[writer] = []
+                    # Meshes that the participant provides can be read directly through just-in-time mappings
+                    provide_meshes = get_provide_meshes_for_data(writer, data_node)
+                    for provide_mesh in provide_meshes:
+                        # Check all neighbors of the mesh: A jit-mapping will read directly from it
+                        for provide_mesh_neighbor in graph.neighbors(provide_mesh):
+                            # Only use read-data if it reads current data_node
+                            if isinstance(provide_mesh_neighbor,
+                                          ReadDataNode) and provide_mesh_neighbor.data == data_node:
+                                readers_per_writer[writer].append(provide_mesh_neighbor.participant)
+                            elif isinstance(provide_mesh_neighbor, WatchPointNode):
+                                readers_per_writer[writer].append(provide_mesh_neighbor.participant)
+                            elif isinstance(provide_mesh_neighbor, WatchIntegralNode):
+                                readers_per_writer[writer].append(provide_mesh_neighbor.participant)
+                            elif isinstance(provide_mesh_neighbor, ExportNode):
+                                readers_per_writer[writer].append(provide_mesh_neighbor.participant)
+                            elif isinstance(provide_mesh_neighbor, ActionNode):
+                                # Check if action reads or writes data (corresponds to source or target data)
+                                # Check all source-data nodes if they correspond to the current data node
+                                for source in provide_mesh_neighbor.source_data:
+                                    if source == data_node:
+                                        # Use the participant associated with the action
+                                        readers_per_writer[writer].append(provide_mesh_neighbor.participant)
+
+                            # If the provided mesh gets received somewhere, it might get read there
+                            elif isinstance(provide_mesh_neighbor, ReceiveMeshNode):
+                                potential_reader = provide_mesh_neighbor.participant
+                                # Check all potential readers
+                                for potential_reader_neighbor in graph.neighbors(potential_reader):
+                                    if isinstance(potential_reader_neighbor,
+                                                  ReadDataNode) and potential_reader_neighbor.data == data_node:
+                                        readers_per_writer[writer].append(potential_reader)
+                                    # Watchpoint, Watch-integral and export do not specify data
+                                    elif isinstance(potential_reader_neighbor, WatchPointNode):
+                                        readers_per_writer[writer].append(potential_reader)
+                                    elif isinstance(potential_reader_neighbor, WatchIntegralNode):
+                                        readers_per_writer[writer].append(potential_reader)
+                                    elif isinstance(potential_reader_neighbor, ExportNode):
+                                        readers_per_writer[writer].append(potential_reader)
+                                    elif isinstance(potential_reader_neighbor, ActionNode):
+                                        # Actions can have many source datas; check for current data_node
+                                        for source in potential_reader_neighbor.source_data:
+                                            if source == data_node:
+                                                readers_per_writer[writer].append(potential_reader)
+
                 # Add violations according to use/read/write
                 if use_data and read_data and write_data:
-                    # Check if there exists a path from writer to reader or if they are the same
+                    # If all three, use_data, read_data and write_data, are true, then there must be paths from every
+                    # writer to all of his readers
                     data_flow_edges = []
                     # Build a graph from participants involved in exchanges of data node
                     exchanges = [node for node in graph.nodes
@@ -172,12 +219,12 @@ class DataUseReadWriteRule(Rule):
                         data_flow_edges += [(exchange.from_participant, exchange.to_participant)]
                     data_flow_graph = nx.DiGraph()
                     data_flow_graph.add_edges_from(data_flow_edges)
+                    writer_s = set(writers)
                     # Check if data gets read and written by the same participant.
                     # If so, then no exchange is needed.
                     # Otherwise, an exchange is needed.
-                    writer_s = set(writers)
-                    reader_s = set(readers)
                     for writer in writer_s:
+                        reader_s = set(readers_per_writer[writer])
                         for reader in reader_s:
                             # If they are the same, then everything is fine.
                             if reader == writer:
@@ -220,6 +267,22 @@ class DataUseReadWriteRule(Rule):
         return violations
 
 
+# Helper functions
+
+def get_provide_meshes_for_data(participant: ParticipantNode, data: DataNode) -> list[MeshNode]:
+    """
+    This method returns all meshes provided by the given participant that use the given data.
+    :param participant: The participant from which to get the meshes.
+    :param data: The data that the meshes use.
+    :return: A list of all meshes provided by the given participant using the given data.
+    """
+    provide_meshes = []
+    for mesh in participant.provide_meshes:
+        if data in mesh.use_data:
+            provide_meshes.append(mesh)
+    return provide_meshes
+
+
 def filter_use_read_write_data(node) -> bool:
     """
     This method filters nodes, that could potentially use data, read data or write data.
@@ -247,5 +310,10 @@ def filter_use_read_write_data(node) -> bool:
 
 
 def filter_data_exchange(node) -> bool:
+    """
+        This method filters data- and exchange-nodes.
+        :param node: The node to check.
+        :return: True, if the node is a data- or exchange-node, False otherwise.
+    """
     return (isinstance(node, DataNode) or
             isinstance(node, ExchangeNode))

--- a/preciceconfigchecker/rules/m2n_exchange.py
+++ b/preciceconfigchecker/rules/m2n_exchange.py
@@ -1,4 +1,3 @@
-import networkx as nx
 from networkx import Graph
 from precice_config_graph.nodes import ParticipantNode, M2NNode
 from preciceconfigchecker.rule import Rule
@@ -66,8 +65,6 @@ class M2NExchangeRule(Rule):
         for participant in participants:
             if participant not in m2n_participants:
                 violations.append(self.MissingM2NEchangeViolation(participant))
-                # Remove this participant to make the following calculations easier
-                participants.remove(participant)
 
         # Check every M2N for duplicates
         for m2n in m2ns:

--- a/tests/data-rules/use-read-write-not_exchange/precice-config.xml
+++ b/tests/data-rules/use-read-write-not_exchange/precice-config.xml
@@ -10,6 +10,14 @@
   <data:scalar name="Color" />
   <data:scalar name="ErrorColor" />
 
+  <mesh name="Alligator-Mesh" dimensions="2">
+    <use-data name="Color" />
+  </mesh>
+
+  <mesh name="Instigator-Mesh" dimensions="2">
+    <use-data name="Color" />
+  </mesh>
+
   <mesh name="Generator-Mesh" dimensions="2">
     <use-data name="Color" />
     <use-data name="ErrorColor" />
@@ -38,12 +46,50 @@
     <read-data name="ErrorColor" mesh="Propagator-Mesh" />
   </participant>
 
-  <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".." />
+  <participant name="Alligator">
+    <provide-mesh name="Alligator-Mesh"/>
+    <receive-mesh name="Generator-Mesh" from="Generator" api-access="true"/>
+    <!-- just-in-time mapping -->
+    <mapping:nearest-neighbor
+            direction="read"
+            from="Generator-Mesh"
+            constraint="consistent"/>
+    <read-data name="Color" mesh="Generator-Mesh"/>
+  </participant>
 
-  <coupling-scheme:serial-explicit>
-    <participants first="Generator" second="Propagator" />
+  <participant name="Instigator">
+    <provide-mesh name="Instigator-Mesh"/>
+    <receive-mesh name="Generator-Mesh" from="Generator" api-access="true"/>
+    <!-- regular mapping -->
+    <mapping:nearest-neighbor
+            direction="read"
+            to="Instigator-Mesh"
+            from="Generator-Mesh"
+            constraint="consistent"/>
+    <read-data name="Color" mesh="Instigator-Mesh"/>
+  </participant>
+
+  <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".." />
+  <m2n:sockets acceptor="Generator" connector="Alligator" exchange-directory=".." />
+  <m2n:sockets acceptor="Generator" connector="Instigator" exchange-directory=".." />
+
+
+  <coupling-scheme:multi>
+    <participant name="Generator" control="yes" />
+    <participant name="Propagator"/>
+    <participant name="Alligator"/>
+    <participant name="Instigator"/>
     <time-window-size value="0.01" />
     <max-time value="0.3" />
+    <acceleration:IQN-ILS>
+      <data name="Color" mesh="Generator-Mesh" scaling="1e6" />
+      <preconditioner type="constant" />
+      <filter type="QR1-absolute" limit="1e-12" />
+      <initial-relaxation value="0.001" />
+      <max-used-iterations value="100" />
+      <time-windows-reused value="8" />
+    </acceleration:IQN-ILS>
     <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator" />
-  </coupling-scheme:serial-explicit>
+  </coupling-scheme:multi>
+
 </precice-configuration>

--- a/tests/data-rules/use-read-write-not_exchange/use-read-write-not_exchange_test.py
+++ b/tests/data-rules/use-read-write-not_exchange/use-read-write-not_exchange_test.py
@@ -6,22 +6,31 @@ from tests.test_utils import assert_equal_violations, get_actual_violations, cre
 
 
 def test_data_not_use_not_read_not_write():
-    graph = create_graph("tests/data-rules/use-read-write-not_exchange/precice-config.xml")
 
     violations_actual = get_actual_violations(graph)
 
     for node in graph.nodes:
         if isinstance(node, DataNode):
             if node.name == "ErrorColor":
-                n_error_color = node
-        if isinstance(node, ParticipantNode):
+                d_error_color = node
+            elif node.name == "Color":
+                d_color = node
+        elif isinstance(node, ParticipantNode):
             if node.name == "Generator":
-                n_generator = node
+                p_generator = node
             elif node.name == "Propagator":
-                n_propagator = node
+                p_propagator = node
+            elif node.name == "Alligator":
+                p_alligator = node
+            elif node.name == "Instigator":
+                p_instigator = node
 
     violations_expected = []
     # ErrorColor gets written by participant Generator and read by Propagator, but not exchanged between them
-    violations_expected += [d.DataNotExchangedViolation(n_error_color, n_generator, n_propagator)]
+    violations_expected += [d.DataNotExchangedViolation(d_error_color, p_generator, p_propagator),
 
-    assert_equal_violations("Data-not-exchanged-test", violations_actual, violations_expected)
+                            d.DataNotExchangedViolation(d_color, p_generator, p_alligator),
+
+                            d.DataNotExchangedViolation(d_color, p_generator, p_instigator)]
+
+    assert_equal_violations("Data-not-exchanged-test", violations_expected, violations_actual)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,8 +33,8 @@ def assert_equal_violations(test_name: str, violations_expected: list[Violation]
         :return: AssertionError, if the violations are not equal
     """
     # Sort them so that violations of the same type are in the same order
-    violations_expected_s = sorted(violations_expected, key=lambda obj: type(obj).__name__)
-    violations_actual_s = sorted(violations_actual, key=lambda obj: type(obj).__name__)
+    violations_expected_s = sorted(violations_expected, key=sort_key)
+    violations_actual_s = sorted(violations_actual, key=sort_key)
 
     assert len(violations_actual_s) == len(violations_expected_s), (
         f"[{test_name}] Different number of expected- and actual violations.\n"
@@ -78,3 +78,6 @@ def create_graph(path: str) -> Graph:
     xml = xml_processing.parse_file(path)
     graph = g.get_graph(xml)
     return graph
+
+def sort_key(obj):
+    return obj.format_explanation()


### PR DESCRIPTION
(sorry @s3n-w6i , didn't want to create different prs for that) 

- *data not exchanged violation*: now only creates violations if a path between a writer and his readers doesn't exist
- *m2n rule*: fixed an issue where additional violations were skipped after finding one
- *test utils*: sorting was only based on object (violation) names, which could lead to violations with different explanations (i.e., different violations) but the same object-type to not get sorted correctly. this is not fixed, by sorting based on violation explanation, which should be unique to every violation