### PR TITLE
Refactor data rule output

### DIFF
--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -260,8 +260,7 @@ class DataUseReadWriteRule(Rule):
                                         for source in potential_reader_neighbor.source_data:
                                             if source == data_node:
                                                 readers_per_writer[writer].append(potential_reader)
-                print("readers per mesh", readers_per_mesh)
-                print("writers per mesh", writers_per_mesh)
+                                                
                 # Add violations according to use/read/write
                 if use_data and read_data and write_data:
                     # If all three, use_data, read_data and write_data, are true, then there must be paths from every

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import networkx as nx
 from networkx import Graph
 from precice_config_graph.nodes import DataNode, MeshNode, ReadDataNode, WriteDataNode, WatchPointNode, ExportNode, \
@@ -32,12 +33,25 @@ class DataUseReadWriteRule(Rule):
             This violation handles someone using a data node, but nobody is reading and writing said data node.
         """
 
-        def __init__(self, data_node: DataNode, mesh: MeshNode):
+        def __init__(self, data_node: DataNode, meshes: list[MeshNode]):
             self.data_node = data_node
-            self.mesh = mesh
+            self.form = ""
+            if len(meshes) > 1:
+                self.form = "es"
+            meshes_s = sorted(meshes, key=lambda x: x.name)
+            self.names = meshes_s[0].name
+            if len(meshes) > 1:
+                for i in range(1, len(meshes_s) - 1):
+                    self.names += ", "
+                    self.names += meshes_s[i].name
+                # Last mesh has to be connected with "and", the others with a comma.
+                self.names += " and "
+                # Name of last mesh
+                self.names += meshes_s[-1].name
 
         def format_explanation(self) -> str:
-            return f"Data {self.data_node.name} gets used in mesh {self.mesh.name}, but nobody is reading or writing it."
+            # self.form ensures the correct number (multiplicity) for the word mesh (i.e., mesh or meshes)
+            return f"Data {self.data_node.name} gets used in mesh{self.form} {self.names}, but nobody is reading or writing it."
 
         def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant read data {self.data_node.name}.",
@@ -49,15 +63,31 @@ class DataUseReadWriteRule(Rule):
             This class handles someone using and writing a data node, but nobody reading said data node.
         """
 
-        def __init__(self, data_node: DataNode, mesh: MeshNode, writer: ParticipantNode):
+        def __init__(self, data_node: DataNode, mesh: MeshNode, writers: list[ParticipantNode]):
             self.data_node = data_node
             self.mesh = mesh
-            self.writer = writer
+            self.writers = writers
+            # Correct grammar for output
+            self.form = ""
+            self.form2 = "is"
+            if len(writers) > 1:
+                self.form = "s"
+                self.form2 = "are"
+            writers_s = sorted(writers, key=lambda x: x.name)
+            self.names = writers_s[0].name
+            if len(writers) > 1:
+                for i in range(1, len(writers_s) - 1):
+                    self.names += ", "
+                    self.names += writers_s[i].name
+                # Last mesh has to be connected with "and", the others with a comma.
+                self.names += " and "
+                # Name of last mesh
+                self.names += writers_s[-1].name
 
         def format_explanation(self) -> str:
             return (
-                f"Data {self.data_node.name} is used in mesh {self.mesh.name} and participant {self.writer.name} "
-                f"is writing it, but nobody is reading it.")
+                f"Data {self.data_node.name} is used in mesh {self.mesh.name} and participant{self.form} {self.names} "
+                f"{self.form2} writing it, but nobody is reading it.")
 
         def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant read data {self.data_node.name}.",
@@ -70,14 +100,29 @@ class DataUseReadWriteRule(Rule):
             This class handles a mesh using and someone reading a data node, but nobody writing said data node.
         """
 
-        def __init__(self, data_node: DataNode, mesh: MeshNode, reader: ParticipantNode):
+        def __init__(self, data_node: DataNode, mesh: MeshNode, readers: list[ParticipantNode]):
             self.data_node = data_node
             self.mesh = mesh
-            self.reader = reader
+            # Correct grammar for output
+            self.form = ""
+            self.form2 = "is"
+            if len(readers) > 1:
+                self.form = "s"
+                self.form2 = "are"
+            readers_s = sorted(readers, key=lambda x: x.name)
+            self.names = readers_s[0].name
+            if len(readers) > 1:
+                for i in range(1, len(readers_s) - 1):
+                    self.names += ", "
+                    self.names += readers_s[i].name
+                # Last mesh has to be connected with "and", the others with a comma.
+                self.names += " and "
+                # Name of last mesh
+                self.names += readers_s[-1].name
 
         def format_explanation(self) -> str:
-            return (f"Data {self.data_node.name} is being used in mesh {self.mesh.name} and participant "
-                    f"{self.reader.name} is reading it, but nobody is writing it.")
+            return (f"Data {self.data_node.name} is being used in mesh {self.mesh.name} and participant{self.form} "
+                    f"{self.names} {self.form2} reading it, but nobody is writing it.")
 
         def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant write {self.data_node.name}.",
@@ -114,7 +159,9 @@ class DataUseReadWriteRule(Rule):
                 meshes: list[MeshNode] = []
                 writers: list[ParticipantNode] = []
                 readers: list[ParticipantNode] = []
-                readers_per_writer: map[ParticipantNode: list[ParticipantNode]] = {}
+                readers_per_writer: dict[ParticipantNode: list[ParticipantNode]] = {}
+                readers_per_mesh: dict[MeshNode: list[ParticipantNode]] = {}
+                writers_per_mesh: dict[MeshNode: list[ParticipantNode]] = {}
 
                 # Check all neighbors of the data node for use-, reader- and writer-nodes
                 for neighbor in g1.neighbors(data_node):
@@ -130,12 +177,15 @@ class DataUseReadWriteRule(Rule):
                             if isinstance(mesh_neighbor, ExportNode):
                                 read_data = True
                                 readers += [mesh_neighbor.participant]
+                                append_participant_to_map(readers_per_mesh, neighbor, mesh_neighbor.participant)
                             elif isinstance(mesh_neighbor, WatchPointNode):
                                 read_data = True
                                 readers += [mesh_neighbor.participant]
+                                append_participant_to_map(readers_per_mesh, neighbor, mesh_neighbor.participant)
                             elif isinstance(mesh_neighbor, WatchIntegralNode):
                                 read_data = True
                                 readers += [mesh_neighbor.participant]
+                                append_participant_to_map(readers_per_mesh, neighbor, mesh_neighbor.participant)
                             elif isinstance(mesh_neighbor, ActionNode):
                                 # Check if action reads or writes data (corresponds to source or target data)
                                 # Check all source-data nodes if they correspond to the current data node
@@ -144,21 +194,25 @@ class DataUseReadWriteRule(Rule):
                                         read_data = True
                                         # Use the participant associated with the action
                                         readers += [mesh_neighbor.participant]
+                                        append_participant_to_map(readers_per_mesh, neighbor, mesh_neighbor.participant)
                                 # Check if the target data corresponds to the current data node
                                 if mesh_neighbor.target_data == data_node:
                                     write_data = True
                                     # Use the participant associated with the action
                                     writers += [mesh_neighbor.participant]
+                                    append_participant_to_map(writers_per_mesh, neighbor, mesh_neighbor.participant)
 
                     # Check if data gets read by a participant.
                     # Only read-data nodes reading current data_node are connected to it
                     elif isinstance(neighbor, ReadDataNode):
                         read_data = True
                         readers += [neighbor.participant]
+                        append_participant_to_map(readers_per_mesh, neighbor.mesh, neighbor.participant)
                     # Check if data gets written by a participant
                     elif isinstance(neighbor, WriteDataNode):
                         write_data = True
                         writers += [neighbor.participant]
+                        append_participant_to_map(writers_per_mesh, neighbor.mesh, neighbor.participant)
 
                 # For every writer, identify the corresponding set of readers
                 for writer in writers:
@@ -206,7 +260,8 @@ class DataUseReadWriteRule(Rule):
                                         for source in potential_reader_neighbor.source_data:
                                             if source == data_node:
                                                 readers_per_writer[writer].append(potential_reader)
-
+                print("readers per mesh", readers_per_mesh)
+                print("writers per mesh", writers_per_mesh)
                 # Add violations according to use/read/write
                 if use_data and read_data and write_data:
                     # If all three, use_data, read_data and write_data, are true, then there must be paths from every
@@ -242,16 +297,13 @@ class DataUseReadWriteRule(Rule):
                                         violations.append(self.DataNotExchangedViolation(data_node, writer, reader))
 
                 elif use_data and read_data and not write_data:
-                    for mesh in meshes:
-                        for reader in readers:
-                            violations.append(self.DataUsedReadNotWrittenViolation(data_node, mesh, reader))
+                    for mesh in readers_per_mesh.keys():
+                        violations.append(self.DataUsedReadNotWrittenViolation(data_node, mesh, readers_per_mesh[mesh]))
                 elif use_data and not read_data and write_data:
-                    for mesh in meshes:
-                        for writer in writers:
-                            violations.append(self.DataUsedNotReadWrittenViolation(data_node, mesh, writer))
+                    for mesh in writers_per_mesh.keys():
+                        violations.append(self.DataUsedNotReadWrittenViolation(data_node, mesh, writers_per_mesh[mesh]))
                 elif use_data and not read_data and not write_data:
-                    for mesh in meshes:
-                        violations.append(self.DataUsedNotReadNotWrittenViolation(data_node, mesh))
+                    violations.append(self.DataUsedNotReadNotWrittenViolation(data_node, meshes))
 
                 elif not use_data and read_data and write_data:
                     # This case gets handled by precice-tools check
@@ -317,3 +369,17 @@ def filter_data_exchange(node) -> bool:
     """
     return (isinstance(node, DataNode) or
             isinstance(node, ExchangeNode))
+
+
+def append_participant_to_map(dictionary: dict[MeshNode: list[ParticipantNode]], mesh, participant):
+    """
+        This method appends the given participant to the given map for an entry 'mesh'.
+        If the map entry for mesh is none, then a new entry is created.
+        :param dictionary: The map to append to.
+        :param mesh: The mesh which entries should be appended.
+        :param participant: The participant to append to the mesh.
+    """
+    try:
+        dictionary[mesh] += [participant]
+    except KeyError:
+        dictionary[mesh] = [participant]

--- a/tests/data-rules/use-not_read-not_write/use-not_read-not_write_test.py
+++ b/tests/data-rules/use-not_read-not_write/use-not_read-not_write_test.py
@@ -20,6 +20,6 @@ def test_data_not_use_not_read_not_write():
 
     violations_expected = []
     # ErrorColor gets used in Generator-Mesh, does not get read/written
-    violations_expected += [d.DataUsedNotReadNotWrittenViolation(n_error_color, n_mesh)]
+    violations_expected += [d.DataUsedNotReadNotWrittenViolation(n_error_color, [n_mesh])]
 
     assert_equal_violations("Data used, not read, not written-test", violations_actual, violations_expected)

--- a/tests/data-rules/use-not_read-write/use-not_read-write_test.py
+++ b/tests/data-rules/use-not_read-write/use-not_read-write_test.py
@@ -23,6 +23,6 @@ def test_data_not_use_not_read_not_write():
 
     violations_expected = []
     # ErrorColor gets used in Generator-Mesh, does not get read, gets written by participant Generator
-    violations_expected += [d.DataUsedNotReadWrittenViolation(n_error_color, n_mesh, n_generator)]
+    violations_expected += [d.DataUsedNotReadWrittenViolation(n_error_color, n_mesh, [n_generator])]
 
     assert_equal_violations("Data used, not read, written-test", violations_actual, violations_expected)

--- a/tests/data-rules/use-read-not_write/precice-config.xml
+++ b/tests/data-rules/use-read-not_write/precice-config.xml
@@ -7,41 +7,65 @@
       enabled="true" />
   </log>
 
-  <data:scalar name="Color" />
+  <data:scalar name="BigMac"/>
   <data:scalar name="ErrorColor" />
 
-  <mesh name="Generator-Mesh" dimensions="2">
-    <use-data name="Color" />
+  <mesh name="Food-Generator-Mesh" dimensions="2">
+    <use-data name="BigMac" />
     <use-data name="ErrorColor" />
   </mesh>
 
+  <mesh name="Water-Generator-Mesh" dimensions="2">
+    <use-data name="BigMac" />
+    <use-data name="ErrorColor" />
+  </mesh>
+
+  <mesh name="Alligator-Mesh" dimensions="2">
+    <use-data name="BigMac"/>
+    <use-data name="ErrorColor"/>
+  </mesh>
+
   <mesh name="Propagator-Mesh" dimensions="2">
-    <use-data name="Color" />
+    <use-data name="BigMac" />
   </mesh>
 
   <participant name="Generator">
-    <provide-mesh name="Generator-Mesh" />
-    <write-data name="Color" mesh="Generator-Mesh" />
-    <read-data name="ErrorColor" mesh="Generator-Mesh" />
+    <provide-mesh name="Food-Generator-Mesh" />
+    <provide-mesh name="Water-Generator-Mesh" />
+    <write-data name="BigMac" mesh="Water-Generator-Mesh" />
+    <read-data name="ErrorColor" mesh="Food-Generator-Mesh" />
+    <read-data name="ErrorColor" mesh="Water-Generator-Mesh" />
   </participant>
 
   <participant name="Propagator">
-    <receive-mesh name="Generator-Mesh" from="Generator" />
+    <receive-mesh name="Water-Generator-Mesh" from="Generator" />
     <provide-mesh name="Propagator-Mesh" />
     <mapping:nearest-neighbor
       direction="read"
-      from="Generator-Mesh"
+      from="Water-Generator-Mesh"
       to="Propagator-Mesh"
       constraint="consistent" />
-    <read-data name="Color" mesh="Propagator-Mesh" />
+    <read-data name="BigMac" mesh="Propagator-Mesh" />
+  </participant>
+
+  <participant name="Alligator">
+    <provide-mesh name="Alligator-Mesh"/>
+    <receive-mesh name="Water-Generator-Mesh" from="Generator" api-access="true"/>
+    <!-- just-in-time mapping -->
+    <mapping:nearest-neighbor
+            direction="read"
+            from="Water-Generator-Mesh"
+            constraint="consistent"/>
+    <read-data name="ErrorColor" mesh="Water-Generator-Mesh"/>
   </participant>
 
   <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".." />
+  <m2n:sockets acceptor="Generator" connector="Alligator" exchange-directory=".." />
 
   <coupling-scheme:serial-explicit>
     <participants first="Generator" second="Propagator" />
     <time-window-size value="0.01" />
     <max-time value="0.3" />
-    <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator" />
+    <exchange data="BigMac" mesh="Water-Generator-Mesh" from="Generator" to="Propagator" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/data-rules/use-read-not_write/use-read-not_write_test.py
+++ b/tests/data-rules/use-read-not_write/use-read-not_write_test.py
@@ -13,16 +13,23 @@ def test_data_not_use_not_read_not_write():
     for node in graph.nodes:
         if isinstance(node, DataNode):
             if node.name == "ErrorColor":
-                n_error_color = node
-        if isinstance(node, MeshNode):
-            if node.name == "Generator-Mesh":
-                n_mesh = node
-        if isinstance(node, ParticipantNode):
+                d_error_color = node
+        elif isinstance(node, ParticipantNode):
             if node.name == "Generator":
-                n_generator = node
+                p_generator = node
+            elif node.name == "Alligator":
+                p_alligator = node
+        elif isinstance(node, MeshNode):
+            if node.name == "Water-Generator-Mesh":
+                m_water_generator = node
+            elif node.name == "Food-Generator-Mesh":
+                m_food_generator = node
 
     violations_expected = []
     # ErrorColor gets used in Generator-Mesh, gets read by participant Generator, does not get written
-    violations_expected += [d.DataUsedReadNotWrittenViolation(n_error_color, n_mesh, n_generator)]
+    violations_expected += [
+        d.DataUsedReadNotWrittenViolation(d_error_color, m_water_generator, [p_generator, p_alligator]),
+
+        d.DataUsedReadNotWrittenViolation(d_error_color, m_food_generator, [p_generator])]
 
     assert_equal_violations("Data used, read, not written-test", violations_actual, violations_expected)

--- a/tests/data-rules/use-read-write-not_exchange/precice-config.xml
+++ b/tests/data-rules/use-read-write-not_exchange/precice-config.xml
@@ -10,6 +10,10 @@
   <data:scalar name="Color" />
   <data:scalar name="ErrorColor" />
 
+  <mesh name="Elevator-Mesh" dimensions="2">
+    <use-data name="Color" />
+  </mesh>
+
   <mesh name="Alligator-Mesh" dimensions="2">
     <use-data name="Color" />
   </mesh>
@@ -57,6 +61,17 @@
     <read-data name="Color" mesh="Generator-Mesh"/>
   </participant>
 
+  <participant name="Elevator">
+    <provide-mesh name="Elevator-Mesh"/>
+    <receive-mesh name="Generator-Mesh" from="Generator" api-access="true"/>
+    <mapping:nearest-neighbor
+            direction="read"
+            from="Generator-Mesh"
+            to="Elevator-Mesh"
+            constraint="consistent"/>
+    <read-data name="ErrorColor" mesh="Elevator-Mesh"/>
+  </participant>
+
   <participant name="Instigator">
     <provide-mesh name="Instigator-Mesh"/>
     <receive-mesh name="Generator-Mesh" from="Generator" api-access="true"/>
@@ -72,7 +87,7 @@
   <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".." />
   <m2n:sockets acceptor="Generator" connector="Alligator" exchange-directory=".." />
   <m2n:sockets acceptor="Generator" connector="Instigator" exchange-directory=".." />
-
+  <m2n:sockets acceptor="Generator" connector="Elevator" exchange-directory=".." />
 
   <coupling-scheme:multi>
     <participant name="Generator" control="yes" />
@@ -91,5 +106,12 @@
     </acceleration:IQN-ILS>
     <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator" />
   </coupling-scheme:multi>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Generator" second="Elevator" />
+    <time-window-size value="0.01" />
+    <max-time value="0.3" />
+    <exchange data="ErrorColor" mesh="Generator-Mesh" from="Generator" to="Elevator" />
+  </coupling-scheme:serial-explicit>
 
 </precice-configuration>


### PR DESCRIPTION
before, for every combination of mesh and writer/reader a violation was created:
mesh M (uses data D), read by participant A and participant C

mesh N (uses data D), read by participant B 

=> result:
1. M uses D and A reads, but nobody writes
2. M uses D and B reads, but nobody writes
3. M uses D and C reads, but nobody writes
4. N uses D and A reads, but nobody writes
5. N uses D and B reads, but nobody writes

Here, 2. and 4. are not entirely correct.

Now, the result would be:
1. M uses D and A and C read, but nobody writes
2. N uses D and B reads, but nobody writes