### PR TITLE
Mapping data processing adjustments

### DIFF
--- a/preciceconfigchecker/rules/mapping.py
+++ b/preciceconfigchecker/rules/mapping.py
@@ -1,6 +1,7 @@
 from networkx.classes import Graph
 from precice_config_graph.nodes import ParticipantNode, MeshNode, MappingNode, Direction, MappingConstraint, \
-    MappingMethod, CouplingSchemeNode, MultiCouplingSchemeNode, CouplingSchemeType, ExchangeNode, M2NNode, WriteDataNode, \
+    MappingMethod, CouplingSchemeNode, MultiCouplingSchemeNode, CouplingSchemeType, ExchangeNode, M2NNode, \
+    WriteDataNode, \
     ReadDataNode, ActionNode, ExportNode, WatchPointNode, WatchIntegralNode
 from preciceconfigchecker.rule_utils import rule_error_message
 from preciceconfigchecker.rule import Rule
@@ -867,19 +868,6 @@ def get_m2n_of_participants(m2ns: list[M2NNode], participant_a: ParticipantNode,
         elif m2n.acceptor == participant_b and m2n.connector == participant_a:
             return m2n
     return None
-
-
-def data_processing_belongs_to_mapping(data_processing: WriteDataNode | ReadDataNode, mesh: MeshNode) -> bool:
-    """
-        This function evaluates whether the given data-processing node is valid for a mapping,
-        defined by the given mesh.
-        It is assumed that the data_processing node is specified by the parent of the mapping,
-        and that the mesh is the mesh that would be expected in a correct data_processing.
-        :param data_processing: The data-processing node, either a write-data node or a read-data node.
-        :param mesh: The mesh that would be expected in a correct data_processing.
-        :return: True, if the data-processing node is valid for the mapping, False otherwise.
-    """
-    return mesh == data_processing.mesh
 
 
 def exchange_belongs_to_mapping(exchange: ExchangeNode, direction: Direction, participant_stranger: ParticipantNode,

--- a/preciceconfigchecker/rules/mapping.py
+++ b/preciceconfigchecker/rules/mapping.py
@@ -30,7 +30,7 @@ class MappingRule(Rule):
         def format_explanation(self) -> str:
             out: str = (f"The participant {self.participant.name} is specifying a {self.direction.value}-mapping "
                         f"{self.connecting_word} mesh {self.mesh.name}, which is his own mesh.")
-            out += f"The mapping is from participant {self.participant.name} to participant {self.participant.name}."
+            out += f"\nThe mapping is on {self.participant.name}'s own meshes, which is forbidden."
             return out
 
         def format_possible_solutions(self) -> list[str]:
@@ -141,7 +141,7 @@ class MappingRule(Rule):
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
-            out += [f"Create a coupling-scheme between participants {self.parent.name} and {self.stranger.name} with an"
+            out += [f"Create a coupling-scheme between participants {self.parent.name} and {self.stranger.name} with an "
                     f"exchange to exchange data between them."]
             out += ["Otherwise, please remove the mapping to improve readability."]
             return out

--- a/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
+++ b/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
@@ -1,6 +1,6 @@
 from preciceconfigchecker.rules.disjoint_simulations import DisjointSimulationsRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as c
-from preciceconfigchecker.rules.mapping import MappingRule as m
+from preciceconfigchecker.rules.mapping import MappingRule as m, MissingDataProcessing as mdp
 from tests.test_utils import assert_equal_violations, create_graph, get_actual_violations
 from precice_config_graph.nodes import ParticipantNode, MeshNode, DataNode, Direction
 
@@ -46,7 +46,7 @@ def test_coupling_scheme_mapping():
         d.SharedDataDisjointSimulationsViolation(d_color, frozenset([frozenset([p_generator, p_propagator, p_elevator]),
                                                                      frozenset([p_alligator, p_instigator])])),
         m.JustInTimeMappingMissingDataProcessingViolation(p_alligator, p_instigator, m_instigator, Direction.WRITE,
-                                                          m.MissingDataProcessing.READ_DATA)
+                                                          mdp.READ_DATA)
     ]
 
     assert_equal_violations("Coupling-scheme-mapping-test", violations_expected, violations_actual)

--- a/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
+++ b/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
@@ -1,7 +1,8 @@
 from preciceconfigchecker.rules.disjoint_simulations import DisjointSimulationsRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as c
+from preciceconfigchecker.rules.mapping import MappingRule as m
 from tests.test_utils import assert_equal_violations, create_graph, get_actual_violations
-from precice_config_graph.nodes import ParticipantNode, MeshNode, DataNode
+from precice_config_graph.nodes import ParticipantNode, MeshNode, DataNode, Direction
 
 
 def test_coupling_scheme_mapping():
@@ -31,13 +32,21 @@ def test_coupling_scheme_mapping():
                 m_propagator = node
             elif node.name == "Alligator-Mesh":
                 m_alligator = node
+            elif node.name == "Instigator-Mesh":
+                m_instigator = node
 
     violations_expected = [
+
         c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator),
+
         c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator),
+
         c.MissingMappingAPIAccessCouplingSchemeViolation(p_alligator, p_instigator, m_alligator),
+
         d.SharedDataDisjointSimulationsViolation(d_color, frozenset([frozenset([p_generator, p_propagator, p_elevator]),
-                                                                     frozenset([p_alligator, p_instigator])]))
+                                                                     frozenset([p_alligator, p_instigator])])),
+        m.JustInTimeMappingMissingDataProcessingViolation(p_alligator, p_instigator, m_instigator, Direction.WRITE,
+                                                          m.MissingDataProcessing.READ_DATA)
     ]
 
     assert_equal_violations("Coupling-scheme-mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -88,7 +88,9 @@ def test_mapping():
 
         d.DataNotExchangedViolation(d_color, p_generator, p_alligator),
 
-        d.DataNotExchangedViolation(d_color, p_instigator, p_elevator)
+        d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
+
+        d.DataNotExchangedViolation(d_color, p_propagator, p_incinerator)
     ]
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -1,6 +1,6 @@
 from precice_config_graph.nodes import ParticipantNode, MeshNode, Direction, MappingConstraint, MappingMethod, DataNode
 
-from preciceconfigchecker.rules.mapping import MappingRule as m, MappingRule
+from preciceconfigchecker.rules.mapping import MappingRule as m
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
@@ -76,7 +76,7 @@ def test_mapping():
         m.MissingM2NMappingViolation(p_incinerator, p_propagator, m_propagator, Direction.READ),
 
         m.MappingMissingDataProcessingViolation(p_propagator, p_generator, m_propagator, m_generator, Direction.WRITE,
-                                                MappingRule.MissingDataProcessing.READ_DATA),
+                                                m.MissingDataProcessing.READ_DATA),
 
         mn.MissingM2NEchangeViolation(p_incinerator),
 

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -9,7 +9,7 @@ from tests.test_utils import assert_equal_violations, get_actual_violations, cre
 
 
 def test_mapping():
-    graph = create_graph("precice-config.xml")
+    graph = create_graph("tests/mapping/precice-config.xml")
 
     violations_actual = get_actual_violations(graph)
 

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -1,6 +1,6 @@
 from precice_config_graph.nodes import ParticipantNode, MeshNode, Direction, MappingConstraint, MappingMethod, DataNode
 
-from preciceconfigchecker.rules.mapping import MappingRule as m
+from preciceconfigchecker.rules.mapping import MappingRule as m, MissingDataProcessing as mdp
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
@@ -76,8 +76,7 @@ def test_mapping():
         m.MissingM2NMappingViolation(p_incinerator, p_propagator, m_propagator, Direction.READ),
 
         m.MappingMissingDataProcessingViolation(p_propagator, p_generator, m_propagator, m_generator, Direction.WRITE,
-                                                m.MissingDataProcessing.READ_DATA),
-
+                                                mdp.READ_DATA),
         mn.MissingM2NEchangeViolation(p_incinerator),
 
         d.DataNotExchangedViolation(d_color, p_generator, p_alligator),

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -1,16 +1,15 @@
 from precice_config_graph.nodes import ParticipantNode, MeshNode, Direction, MappingConstraint, MappingMethod, DataNode
 
-from preciceconfigchecker.rules.mapping import MappingRule as m
+from preciceconfigchecker.rules.mapping import MappingRule as m, MappingRule
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
-from preciceconfigchecker.rules_processing import print_all_results, check_all_rules
 
 from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph
 
 
 def test_mapping():
-    graph = create_graph("tests/mapping/precice-config.xml")
+    graph = create_graph("precice-config.xml")
 
     violations_actual = get_actual_violations(graph)
 
@@ -76,7 +75,8 @@ def test_mapping():
 
         m.MissingM2NMappingViolation(p_incinerator, p_propagator, m_propagator, Direction.READ),
 
-        m.MappingMissingDataProcessingViolation(p_propagator, p_generator, m_propagator, m_generator, Direction.WRITE),
+        m.MappingMissingDataProcessingViolation(p_propagator, p_generator, m_propagator, m_generator, Direction.WRITE,
+                                                MappingRule.MissingDataProcessing.READ_DATA),
 
         mn.MissingM2NEchangeViolation(p_incinerator),
 
@@ -86,13 +86,11 @@ def test_mapping():
 
         d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
 
-        csm.MissingMappingCouplingSchemeViolation(p_propagator,p_generator, m_propagator),
+        csm.MissingMappingCouplingSchemeViolation(p_propagator, p_generator, m_propagator),
 
         csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator),
 
         csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator)
     ]
-    print_all_results(check_all_rules(graph,True),True)
-
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -4,6 +4,7 @@ from preciceconfigchecker.rules.mapping import MappingRule as m
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
+from preciceconfigchecker.rules_processing import print_all_results, check_all_rules
 
 from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph
 
@@ -19,12 +20,12 @@ def test_mapping():
             if node.name == "Color":
                 d_color = node
         elif isinstance(node, ParticipantNode):
-            if node.name == "Alligator":
-                p_alligator = node
-            elif node.name == "Generator":
+            if node.name == "Generator":
                 p_generator = node
             elif node.name == "Propagator":
                 p_propagator = node
+            elif node.name == "Alligator":
+                p_alligator = node
             elif node.name == "Instigator":
                 p_instigator = node
             elif node.name == "Elevator":
@@ -32,12 +33,12 @@ def test_mapping():
             elif node.name == "Incinerator":
                 p_incinerator = node
         elif isinstance(node, MeshNode):
-            if node.name == "Alligator-Mesh":
-                m_alligator = node
-            elif node.name == "Generator-Mesh":
+            if node.name == "Generator-Mesh":
                 m_generator = node
             elif node.name == "Propagator-Mesh":
                 m_propagator = node
+            elif node.name == "Alligator-Mesh":
+                m_alligator = node
             elif node.name == "Instigator-Mesh":
                 m_instigator = node
             elif node.name == "Elevator-Mesh":
@@ -75,23 +76,23 @@ def test_mapping():
 
         m.MissingM2NMappingViolation(p_incinerator, p_propagator, m_propagator, Direction.READ),
 
-        mn.MissingM2NEchangeViolation(p_incinerator),
-
         m.MappingMissingDataProcessingViolation(p_propagator, p_generator, m_propagator, m_generator, Direction.WRITE),
 
-        d.DataNotExchangedViolation(d_color, p_generator, p_alligator),
+        mn.MissingM2NEchangeViolation(p_incinerator),
 
-        d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
+        d.DataNotExchangedViolation(d_color, p_generator, p_alligator),
 
         d.DataNotExchangedViolation(d_color, p_propagator, p_incinerator),
 
         d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
 
-        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator),
+        csm.MissingMappingCouplingSchemeViolation(p_propagator,p_generator, m_propagator),
 
         csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator),
 
-        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator)
+        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator)
     ]
+    print_all_results(check_all_rules(graph,True),True)
+
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/precice-config.xml
+++ b/tests/mapping/precice-config.xml
@@ -73,7 +73,8 @@
                 to="Propagator-Mesh"
                 from="Generator-Mesh"
                 constraint="consistent"/>
-        <read-data name="Color" mesh="Propagator-Mesh"/>
+        <read-data name="Color" mesh="Propagator-Mesh" />
+        <write-data name="Color" mesh="Propagator-Mesh" />
     </participant>
 
     <participant name="Alligator">
@@ -85,6 +86,8 @@
                 from="Generator-Mesh"
                 constraint="consistent"/>
         <read-data name="Color" mesh="Generator-Mesh"/>
+        <write-data name="Color" mesh="Alligator-Mesh" />
+        <read-data name="Color" mesh="Alligator-Mesh" />
     </participant>
 
     <participant name="Instigator">
@@ -102,6 +105,7 @@
             constraint="consistent"/>
         <read-data name="Color" mesh="Alligator-Mesh"/>
         <write-data name="Color" mesh="Alligator-Mesh"/>
+        <write-data name="Color" mesh="Instigator-Mesh" />
     </participant>
 
     <participant name="Elevator">
@@ -182,6 +186,6 @@
         <time-window-size value="0.01"/>
         <max-time value="0.3"/>
         <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator"/>
-        <exchange data="Color" mesh="Propagator-Mesh" to="Propagator" from="Generator"/>
+        <exchange data="Color" mesh="Propagator-Mesh" from="Propagator" to="Generator"/>
     </coupling-scheme:serial-explicit>
 </precice-configuration>


### PR DESCRIPTION
Mapping Rule got a lot smarter:
For every mapping:
- Instead of just checking whether a mapping has a corresponding read OR write data, it now gets checked that both exist!
  - This will also be mentioned in the helpful message

This now recognizes a lot more faulty mappings, as can be seen from the adjusted test config.

Regarding the code: 
- The checks for missing data processing violation can be summarized into one, per mapping type (JIT or regular) and direction.
- The check for len(...) > 0 is not necessary anymore, as len(...)=0 already includes the check for correct mesh

TODO:
- [x] Differentiate output to identify which data processing element is missing