### PR TITLE
Coupling scheme needs mapping rule

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -59,7 +59,7 @@ A participant needs to be part of at least one m2n data exchange to exchange dat
 
 - `severity`: `error`
 
-### `Duplicate m2n exchange
+### Duplicate m2n exchange
 
 A participant can be part of more than one m2n exchange,
 but an m2n-exchange between two participants is only allowed to be defined once.
@@ -261,7 +261,7 @@ After declaration, data has to be:
 - used in a mesh
 - written by a participant
 - read by a participant (or read through other means, e.g., of immediate export)
-- exchanged in a coupling-scheme, if it gets written and read by different participants.
+- exchanged in a coupling-scheme if it gets written and read by different participants.
 
 All other cases get checked here (minus the ones that get handled by `precice-tools check`).
 
@@ -314,8 +314,8 @@ This does not necessarily cause the simulation to malfunction or misbehave.
 ## (12) Disjoint simulations
 
 A simulation between participants A and B and a second one between participants C and D can run simultaneously without
-using any of the coupling features of preCICE. This will however deteriorate the readability of the configuration and
-make it more prone to errors.
+using any of the coupling features of preCICE.
+This will, however, deteriorate the readability of the configuration and make it more prone to errors.
 
 ### Fully disjoint
 
@@ -332,3 +332,30 @@ data in any way), but that reference the same data names. This is not considered
 might be an oversight here and will therefore be warned about.
 
 - `severity`: `warning`
+
+## (14) Exchange in coupling-scheme leads to mapping or api-access
+
+If two participants define a coupling-scheme between them, then they need a mapping or api-access to exchange data.
+
+An exchange of the form `from="A" to="B" mesh="A-Mesh"` implies that `A` writes data to `A-mesh`,
+exchanges it to `B`, who either has api-access and reads directly from it or defines a read-mapping to his own mesh.
+
+Analogously, an exchange of the form `from="A" to="B" mesh="B-Mesh"` implies that `A` writes data to one of his meshes
+(or directly to `B-Mesh`with api-access), maps it to `B-Mesh`, exchanges it to `B`, who then reads from it
+
+The same applies to a multi-coupling-scheme.
+
+### Coupling-scheme is missing a mapping
+
+If `A` and `B` do not fulfill the criteria explained above, a violation will be returned.
+
+- `severity`:`error`
+
+### Coupling-scheme with api-access is missing a mapping
+
+If `A` or `B` does have api-access to the correct mesh, it might still lead to an error in the simulation.
+However, as this is a valid use-case, only in debug mode will a warning be displayed.
+
+- `severity`:`debug`
+
+

--- a/preciceconfigchecker/cli.py
+++ b/preciceconfigchecker/cli.py
@@ -8,6 +8,7 @@ from precice_config_graph import graph as g, xml_processing
 
 from preciceconfigchecker.rules_processing import check_all_rules, print_all_results
 
+
 def main():
     path: str = None
     debug: bool = False
@@ -38,6 +39,7 @@ def main():
 
     # if the user uses severity=debug, then the severity has to be passed here as an argument
     print_all_results(violations_by_rule, debug)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -8,7 +8,7 @@ from preciceconfigchecker.violation import Violation
 
 
 class CouplingSchemeMappingRule(Rule):
-    name = "Coupling-scheme rules."
+    name = "Exchange in a coupling-scheme needs a mapping between involved participants."
 
     class MissingMappingCouplingSchemeViolation(Violation):
         """

--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -90,8 +90,6 @@ class CouplingSchemeMappingRule(Rule):
         couplings: list[CouplingSchemeNode | MultiCouplingSchemeNode] = filter_coupling_nodes(graph)
 
         for coupling in couplings:
-            if isinstance(coupling, CouplingSchemeNode):
-
                 # Unknown participants in from=/to= are handled by precice-tools check
 
                 # Check for all exchanges, whether a mapping exists between first and second (in the correct direction)

--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -1,0 +1,194 @@
+from networkx import Graph
+from precice_config_graph.nodes import CouplingSchemeNode, MultiCouplingSchemeNode, ParticipantNode, ExchangeNode, \
+    MeshNode, MappingNode, Direction
+
+from preciceconfigchecker.rule import Rule
+from preciceconfigchecker.severity import Severity
+from preciceconfigchecker.violation import Violation
+
+
+class CouplingSchemeMappingRule(Rule):
+    name = "Coupling-scheme rules."
+
+    class MissingMappingCouplingSchemeViolation(Violation):
+        """
+            A coupling-scheme with a data exchange between two participants exists, but no mapping between them.
+            This means they either need api-access to one-another, or they are missing a mapping.
+            In case they are missing a mapping, there is this violation.
+        """
+        severity = Severity.ERROR
+
+        def __init__(self, from_participant: ParticipantNode, to_participant: ParticipantNode, exchange_mesh: MeshNode):
+            self.from_participant = from_participant
+            self.to_participant = to_participant
+            self.exchange_mesh = exchange_mesh
+            if exchange_mesh in from_participant.provide_meshes:
+                # from_participant writes to own mesh, sends it to to_participant, who maps it to his own mesh, and reads from it
+                self.direction = Direction.READ
+                self.mapper = to_participant
+                self.non_mapper = from_participant
+                self.mesh_owner = from_participant
+            else:
+                # from_participant writes to own mesh, maps it to to_participants mesh, sends it to to_participant, who reads from it
+                self.direction = Direction.WRITE
+                self.mapper = from_participant
+                self.non_mapper = to_participant
+                self.mesh_owner = to_participant
+
+        def format_explanation(self) -> str:
+            return (f"The exchange belonging to the coupling-scheme between participants "
+                    f"{self.from_participant.name} and {self.to_participant.name} using {self.mesh_owner.name}'s "
+                    f"mesh {self.exchange_mesh.name} is missing a mapping.")
+
+        def format_possible_solutions(self) -> list[str]:
+            return [f"For this exchange, {self.mapper.name} has to define a {self.direction.value}-mapping from a "
+                    f"mesh provided by {self.from_participant.name} to a mesh provided by {self.to_participant.name}.",
+                    "Otherwise, change the mesh used in the exchange and make sure that there exists a corresponding "
+                    "mapping for it."]
+
+    class MissingMappingAPIAccessCouplingSchemeViolation(Violation):
+        """
+            A coupling-scheme with a data exchange between two participants exists, but no mapping between them.
+            This means they either need api-access to one-another, or they are missing a mapping.
+            In case they have api-access, there is this violation, as a user can forget to specify a mapping.
+        """
+        severity = Severity.DEBUG
+
+        def __init__(self, from_participant: ParticipantNode, to_participant: ParticipantNode, exchange_mesh: MeshNode):
+            self.from_participant = from_participant
+            self.to_participant = to_participant
+            self.exchange_mesh = exchange_mesh
+            if exchange_mesh in from_participant.provide_meshes:
+                # from_participant writes to own mesh, sends it to to_participant, who maps it to his own mesh, and reads from it
+                self.direction = Direction.READ
+                self.mapper = to_participant
+                self.non_mapper = from_participant
+                self.mesh_owner = from_participant
+            else:
+                # from_participant writes to own mesh, maps it to to_participants mesh, sends it to to_participant, who reads from it
+                self.direction = Direction.WRITE
+                self.mapper = from_participant
+                self.non_mapper = to_participant
+                self.mesh_owner = to_participant
+
+        def format_explanation(self) -> str:
+            out: str = (f"The exchange belonging to the coupling-scheme between participants "
+                        f"{self.from_participant.name} and {self.to_participant.name} using {self.mesh_owner.name}'s "
+                        f"mesh {self.exchange_mesh.name} does not have a mapping.")
+            out += (f"\nThis is valid, because {self.mapper.name} has api-access to {self.non_mapper.name}'s "
+                    f"{self.exchange_mesh.name}, but is more prone to errors.")
+            return out
+
+        def format_possible_solutions(self) -> list[str]:
+            return [
+                f"Specifying a just-in-time {self.direction.value}-mapping at {self.mapper.name} will make the exchange "
+                f"of data more reliable."]
+
+    def check(self, graph: Graph) -> list[Violation]:
+        violations: list[Violation] = []
+
+        couplings: list[CouplingSchemeNode | MultiCouplingSchemeNode] = filter_coupling_nodes(graph)
+
+        for coupling in couplings:
+            if isinstance(coupling, CouplingSchemeNode):
+
+                # Unknown participants in from=/to= are handled by precice-tools check
+
+                # Check for all exchanges, whether a mapping exists between first and second (in the correct direction)
+                exchanges: list[ExchangeNode] = coupling.exchanges
+                for exchange in exchanges:
+                    # Check whose mesh gets used
+                    exchange_mesh = exchange.mesh
+                    from_participant = exchange.from_participant
+                    to_participant = exchange.to_participant
+                    from_meshes = from_participant.provide_meshes
+                    to_meshes = to_participant.provide_meshes
+
+                    # from-participant writes data to from-mesh, exchanges it to to-participant, who maps it to his own
+                    # mesh and then reads from it => READ-mapping by to-participant required, or api-access to from-mesh
+                    if exchange_mesh in from_meshes:
+                        has_correct_mapping: bool = any(
+                            mapping_fits_exchange(mapping, Direction.READ, from_participant, to_participant,
+                                                  exchange_mesh) for mapping in to_participant.mappings)
+                        if has_api_access(to_participant, exchange_mesh):
+                            # If the participant has api-access, then only add a violation if no mapping exists
+                            if not has_correct_mapping:
+                                violations.append(
+                                    self.MissingMappingAPIAccessCouplingSchemeViolation(from_participant,
+                                                                                        to_participant,
+                                                                                        exchange_mesh))
+                        elif not has_correct_mapping:
+                            violations.append(
+                                self.MissingMappingCouplingSchemeViolation(from_participant, to_participant,
+                                                                           exchange_mesh))
+                    # from-participant writes data to own mesh, maps it to to-mesh, exchanges it to to-participant, who
+                    # reads from it => WRITE-mapping by from-participant required, or api-access to to-mesh
+                    elif exchange_mesh in to_meshes:
+                        has_correct_mapping: bool = any(
+                            mapping_fits_exchange(mapping, Direction.WRITE, from_participant, to_participant,
+                                                  exchange_mesh) for mapping in from_participant.mappings)
+
+                        if has_api_access(from_participant, exchange_mesh):
+                            # If the participant has api-access, then only add a violation if no mapping exists
+                            if not has_correct_mapping:
+                                violations.append(
+                                    self.MissingMappingAPIAccessCouplingSchemeViolation(from_participant,
+                                                                                        to_participant,
+                                                                                        exchange_mesh))
+                        elif not has_correct_mapping:
+                            violations.append(
+                                self.MissingMappingCouplingSchemeViolation(from_participant, to_participant,
+                                                                           exchange_mesh))
+
+        return violations
+
+
+def filter_coupling_nodes(graph: Graph) -> list[CouplingSchemeNode | MultiCouplingSchemeNode]:
+    """
+        This function returns all coupling-scheme nodes of the given graph.
+        :param graph:The graph to check.
+        :return: All (multi-)coupling-scheme nodes of the graph.
+    """
+    couplings: list[CouplingSchemeNode | MultiCouplingSchemeNode] = []
+    for node in graph.nodes:
+        if isinstance(node, CouplingSchemeNode) or isinstance(node, MultiCouplingSchemeNode):
+            couplings.append(node)
+    return couplings
+
+
+def mapping_fits_exchange(mapping: MappingNode, direction: Direction, from_participant: ParticipantNode,
+                          to_participant: ParticipantNode, exchange_mesh: MeshNode) -> bool:
+    """
+        This function checks, whether the given mapping fits an exchange indicated by the given direction,
+        first and second participant and mesh used in the exchange.
+    :param mapping: The mapping to check.
+    :param direction: The direction the mapping is supposed to have.
+    :param to_participant: The to= participant in the exchange.
+    :param from_participant: The from= participant in the exchange.
+    :param exchange_mesh: The mesh= used in the exchange.
+    :return: True, if the mapping has the correct direction and meshes.
+    """
+    if mapping.direction != direction:
+        return False
+    if direction == Direction.WRITE:
+        # For direction-write, the mesh used in the exchange needs to be by to-participant
+        if exchange_mesh not in to_participant.provide_meshes:
+            return False
+    elif direction == Direction.READ:
+        # For direction-read, the mesh used in the exchange needs to be by from-participant
+        if exchange_mesh not in from_participant.provide_meshes:
+            return False
+    return True
+
+
+def has_api_access(participant: ParticipantNode, mesh: MeshNode) -> bool:
+    """
+        This function checks, whether the given participant has API access to the given mesh.
+        :param participant: The participant to check.
+        :param mesh: The mesh to check.
+        :return: True, if the participant receives the mesh with api-access=true
+    """
+    for receive_mesh in participant.receive_meshes:
+        if receive_mesh.mesh == mesh and receive_mesh.api_access:
+            return True
+    return False

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -3,7 +3,7 @@ from networkx import Graph
 import preciceconfigchecker.color as c
 from preciceconfigchecker.rule import Rule
 from preciceconfigchecker.rules import missing_coupling, missing_exchange, data_use_read_write, compositional_coupling, \
-    mapping, m2n_exchange, disjoint_simulations
+    mapping, m2n_exchange, disjoint_simulations, coupling_scheme_mapping
 from preciceconfigchecker.severity import Severity
 from preciceconfigchecker.violation import Violation
 
@@ -15,6 +15,7 @@ rules: list[Rule] = [
     m2n_exchange.M2NExchangeRule(),
     mapping.MappingRule(),
     disjoint_simulations.DisjointSimulationsRule(),
+    coupling_scheme_mapping.CouplingSchemeMappingRule()
 ]
 
 def has_satisfied_rules(violations_by_rule: dict[Rule, list[Violation]], debug:bool) -> bool:

--- a/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
+++ b/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
@@ -1,0 +1,43 @@
+from preciceconfigchecker.rules.disjoint_simulations import DisjointSimulationsRule as d
+from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as c
+from tests.test_utils import assert_equal_violations, create_graph, get_actual_violations
+from precice_config_graph.nodes import ParticipantNode, MeshNode, DataNode
+
+
+def test_coupling_scheme_mapping():
+    graph = create_graph("tests/coupling-scheme-mapping/precice-config.xml")
+
+    violations_actual = get_actual_violations(graph)
+
+    for node in graph.nodes:
+        if isinstance(node, DataNode):
+            if node.name == "Color":
+                d_color = node
+        if isinstance(node, ParticipantNode):
+            if node.name == "Generator":
+                p_generator = node
+            elif node.name == "Propagator":
+                p_propagator = node
+            elif node.name == "Alligator":
+                p_alligator = node
+            elif node.name == "Instigator":
+                p_instigator = node
+            elif node.name == "Elevator":
+                p_elevator = node
+        elif isinstance(node, MeshNode):
+            if node.name == "Generator-Mesh":
+                m_generator = node
+            elif node.name == "Propagator-Mesh":
+                m_propagator = node
+            elif node.name == "Alligator-Mesh":
+                m_alligator = node
+
+    violations_expected = [
+        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator),
+        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator),
+        c.MissingMappingAPIAccessCouplingSchemeViolation(p_alligator, p_instigator, m_alligator),
+        d.SharedDataDisjointSimulationsViolation(d_color, frozenset([frozenset([p_generator, p_propagator, p_elevator]),
+                                                                     frozenset([p_alligator, p_instigator])]))
+    ]
+
+    assert_equal_violations("Coupling-scheme-mapping-test", violations_expected, violations_actual)

--- a/tests/coupling-scheme-mapping/precice-config.xml
+++ b/tests/coupling-scheme-mapping/precice-config.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+    <log>
+        <sink
+                filter="%Severity% > debug"
+                format="---[precice] %ColorizedSeverity% %Message%"
+                enabled="true"/>
+    </log>
+
+    <data:scalar name="Color"/>
+
+    <mesh name="Generator-Mesh" dimensions="2">
+        <use-data name="Color"/>
+    </mesh>
+
+    <mesh name="Propagator-Mesh" dimensions="2">
+        <use-data name="Color"/>
+    </mesh>
+
+    <participant name="Generator">
+        <provide-mesh name="Generator-Mesh"/>
+        <receive-mesh name="Propagator-Mesh" from="Propagator"/>
+        <write-data name="Color" mesh="Generator-Mesh"/>
+        <!--<mapping:nearest-neighbor
+                direction="write"
+                from="Generator-Mesh"
+                to="Propagator-Mesh"
+                constraint="conservative"/>-->
+    </participant>
+
+    <participant name="Propagator">
+        <receive-mesh name="Generator-Mesh" from="Generator"/>
+        <provide-mesh name="Propagator-Mesh"/>
+        <read-data name="Color" mesh="Propagator-Mesh"/>
+        <!--<mapping:nearest-neighbor
+                direction="read"
+                from="Generator-Mesh"
+                to="Propagator-Mesh"
+                constraint="consistent"/>-->
+    </participant>
+
+    <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".."/>
+
+    <coupling-scheme:serial-explicit>
+        <participants first="Generator" second="Propagator"/>
+        <time-window-size value="0.01"/>
+        <max-time value="0.3"/>
+        <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator"/>
+        <exchange data="Color" mesh="Propagator-Mesh" from="Generator" to="Propagator"/>
+    </coupling-scheme:serial-explicit>
+
+    <!-- same but with api-access -->
+
+    <mesh name="Alligator-Mesh" dimensions="2">
+        <use-data name="Color"/>
+    </mesh>
+
+    <mesh name="Instigator-Mesh" dimensions="2">
+        <use-data name="Color"/>
+    </mesh>
+
+    <participant name="Alligator">
+        <provide-mesh name="Alligator-Mesh"/>
+        <receive-mesh name="Instigator-Mesh" from="Instigator" api-access="true"/>
+        <write-data name="Color" mesh="Alligator-Mesh"/>
+        <write-data name="Color" mesh="Instigator-Mesh"/>
+        <!-- This jit-mapping fits the
+        <exchange data="Color" mesh="Instigator-Mesh" from="Alligator" to="Instigator"/>
+        tag, which will not create a violation -->
+        <mapping:nearest-neighbor
+                direction="write"
+                to="Instigator-Mesh"
+                constraint="conservative"/>
+    </participant>
+
+    <participant name="Instigator">
+        <!-- this is valid, but should yield a debug-violation as a warning
+             this corresponds to exchange from Alligator to Instigator with mesh Alligator-Mesh -->
+        <receive-mesh name="Alligator-Mesh" from="Alligator" api-access="true"/>
+        <provide-mesh name="Instigator-Mesh"/>
+        <read-data name="Color" mesh="Alligator-Mesh"/>
+    </participant>
+
+    <m2n:sockets acceptor="Alligator" connector="Instigator" exchange-directory=".."/>
+
+    <coupling-scheme:serial-explicit>
+        <participants first="Alligator" second="Instigator"/>
+        <time-window-size value="0.01"/>
+        <max-time value="0.3"/>
+        <exchange data="Color" mesh="Alligator-Mesh" from="Alligator" to="Instigator"/>
+        <exchange data="Color" mesh="Instigator-Mesh" from="Alligator" to="Instigator"/>
+    </coupling-scheme:serial-explicit>
+
+    <!-- valid part, should not cause any violations -->
+
+    <mesh name="Elevator-Mesh" dimensions="2">
+        <use-data name="Color"/>
+    </mesh>
+
+    <participant name="Elevator">
+        <read-data name="Color" mesh="Elevator-Mesh"/>
+        <receive-mesh name="Generator-Mesh" from="Generator"/>
+        <provide-mesh name="Elevator-Mesh"/>
+        <mapping:nearest-neighbor
+                direction="read"
+                from="Generator-Mesh"
+                to="Elevator-Mesh"
+                constraint="consistent"/>
+    </participant>
+
+    <m2n:mpi acceptor="Elevator" connector="Generator" exchange-directory=".."/>≈@
+
+    <coupling-scheme:serial-explicit>
+        <participants first="Elevator" second="Generator"/>
+        <time-window-size value="0.01"/>
+        <max-time value="0.3"/>
+        <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Elevator"/>
+    </coupling-scheme:serial-explicit>
+
+</precice-configuration>
+
+        <!-- <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator"/>
+                indicates a read mapping defined by propagator,
+                because Generator-Mesh gets exchanged from Generator to Propagator,
+                i.e., Generator writes to own mesh, sends it to Propagator, who maps it to his mesh, and reads from it.
+                ==> missing mapping
+            <exchange data="Color" mesh="Propagator-Mesh" from="Generator" to="Propagator"/>
+                would indicate a write-mapping defined by generator,
+                because Propagator-Mesh is exchanged from Generator to Propagator,
+                i.e., Generator writes to own mesh, maps to Propagator mesh, sends it to Propagator, who reads from it
+        -->

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -3,6 +3,8 @@ from precice_config_graph.nodes import ParticipantNode, MeshNode, Direction, Map
 from preciceconfigchecker.rules.mapping import MappingRule as m
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
+from preciceconfigchecker.rules_processing import check_all_rules, print_all_results
+from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
 
 from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph
 
@@ -88,7 +90,11 @@ def test_mapping():
 
         d.DataNotExchangedViolation(d_color, p_generator, p_alligator),
 
-        d.DataNotExchangedViolation(d_color, p_instigator, p_elevator)
+        d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
+
+        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator),
+
+        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator)
     ]
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -85,7 +85,9 @@ def test_mapping():
 
         csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator),
 
-        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator)
+        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator),
+
+        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator)
     ]
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -3,7 +3,6 @@ from precice_config_graph.nodes import ParticipantNode, MeshNode, Direction, Map
 from preciceconfigchecker.rules.mapping import MappingRule as m
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
-from preciceconfigchecker.rules_processing import check_all_rules, print_all_results
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
 
 from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph


### PR DESCRIPTION
Another new update for the config-checker!

We now check, whether an exchange in a coupling-scheme leads to the participants defining a mapping between them. If they don't, then they need api-access.
If this is not granted, then we have found a new error!
