### PR TITLE
Change format solutions wording

### DIFF
--- a/preciceconfigchecker/rules/compositional_coupling.py
+++ b/preciceconfigchecker/rules/compositional_coupling.py
@@ -32,7 +32,7 @@ class CompositionalCouplingRule(Rule):
             return f"Participants {self.names} are involved in a circularly dependent (serial) coupling."
 
         def format_possible_solutions(self) -> list[str]:
-            return [f"Please change the structure of couplings between participants {self.names}."]
+            return [f"Please change the structure of couplings between {self.names}."]
 
     def check(self, graph: Graph) -> list[Violation]:
         violations = []

--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -80,9 +80,8 @@ class CouplingSchemeMappingRule(Rule):
             return out
 
         def format_possible_solutions(self) -> list[str]:
-            return [
-                f"Specifying a just-in-time {self.direction.value}-mapping at {self.mapper.name} will make the exchange "
-                f"of data more reliable."]
+            return [f"Specifying a just-in-time {self.direction.value}-mapping at {self.mapper.name} will make the "
+                    f"exchange of data more reliable."]
 
     def check(self, graph: Graph) -> list[Violation]:
         violations: list[Violation] = []

--- a/preciceconfigchecker/rules/data_use_read_write.py
+++ b/preciceconfigchecker/rules/data_use_read_write.py
@@ -54,9 +54,9 @@ class DataUseReadWriteRule(Rule):
             return f"Data {self.data_node.name} gets used in mesh{self.form} {self.names}, but nobody is reading or writing it."
 
         def format_possible_solutions(self) -> list[str]:
-            return [f"Consider having a participant read data {self.data_node.name}.",
-                    f"Consider having a participant write data {self.data_node.name}.",
-                    "Otherwise please remove it to improve readability."]
+            return [f"Consider having a participant read {self.data_node.name}.",
+                    f"Consider having a participant write {self.data_node.name}.",
+                    "Otherwise, please remove it to improve readability."]
 
     class DataUsedNotReadWrittenViolation(Violation):
         """
@@ -86,14 +86,13 @@ class DataUseReadWriteRule(Rule):
                 self.names += writers_s[-1].name
 
         def format_explanation(self) -> str:
-            return (
-                f"Data {self.data_node.name} is used in mesh {self.mesh.name} and participant{self.form} {self.names} "
-                f"{self.form2} writing it, but nobody is reading it.")
+            return (f"Data {self.data_node.name} is used in mesh {self.mesh.name} and participant{self.form} "
+                    f"{self.names} {self.form2} writing it, but nobody is reading it.")
 
         def format_possible_solutions(self) -> list[str]:
             return [f"Consider having a participant read data {self.data_node.name}.",
-                    f"Consider exporting data {self.data_node.name} by a participant.",
-                    f"Consider using watchpoints or watch-integrals to keep track of data {self.data_node.name}.",
+                    f"Consider exporting {self.data_node.name} by a participant.",
+                    f"Consider using watchpoints or watch-integrals to keep track of {self.data_node.name}.",
                     "Otherwise please remove it to improve readability."]
 
     class DataUsedReadNotWrittenViolation(Violation):
@@ -147,8 +146,8 @@ class DataUseReadWriteRule(Rule):
                     f"but not exchanged between them.")
 
         def format_possible_solutions(self) -> list[str]:
-            return [f"Please exchange {self.data_node.name} in a coupling-scheme between participants "
-                    f"{self.writer.name} and {self.reader.name}"]
+            return [f"Please exchange {self.data_node.name} in a coupling-scheme between {self.writer.name} and "
+                    f"{self.reader.name}"]
 
     def check(self, graph: Graph) -> list[Violation]:
         violations: list[Violation] = []
@@ -172,11 +171,10 @@ class DataUseReadWriteRule(Rule):
                 for neighbor in g1.neighbors(data_node):
                     # Check if data gets used by a mesh
                     if isinstance(neighbor, MeshNode):
-                        # else: continue on not found?
                         try:
                             parent = parents_of_meshes[neighbor]
                         except KeyError:
-                            # TODO Will be handled in mesh.py
+                            # Is handled in provide_mesh.py
                             continue
                         use_data = True
                         meshes += [neighbor]

--- a/preciceconfigchecker/rules/disjoint_simulations.py
+++ b/preciceconfigchecker/rules/disjoint_simulations.py
@@ -23,10 +23,11 @@ class DisjointSimulationsRule(Rule):
             self.participant_sets = participant_sets
 
         def assemble_from_default_explanation(self, details: str = "") -> str:
-            explanation = f"There are {len(self.participant_sets)} simulations that do not interact with each other{details}. "
+            explanation = (f"There are {len(self.participant_sets)} simulations that do not interact with each "
+                           f"other{details}. ")
 
             def format_set(participants: frozenset[ParticipantNode]) -> str:
-                value = [ participant.name for participant in participants ]
+                value = [participant.name for participant in participants]
                 return ", ".join(sorted(value))
 
             if len(self.participant_sets) == 2:
@@ -36,7 +37,8 @@ class DisjointSimulationsRule(Rule):
                 do_str = "do" if len(participants_a) > 1 else "does"
                 participants_b_label = "participants" if len(participants_b) > 1 else "participant"
 
-                explanation += f"{participants_a_label} {format_set(participants_a)} {do_str} not communicate with {participants_b_label} {format_set(participants_b)}."
+                explanation += (f"{participants_a_label} {format_set(participants_a)} {do_str} not communicate with "
+                                f"{participants_b_label} {format_set(participants_b)}.")
             else:
                 explanation += f"Disjoint groups:"
                 for component in self.participant_sets:
@@ -54,9 +56,7 @@ class DisjointSimulationsRule(Rule):
             return self.assemble_from_default_explanation()
 
         def format_possible_solutions(self) -> list[str]:
-            return default_possible_solutions + [
-                "Add some data to be exchanged between these simulations.",
-            ]
+            return default_possible_solutions + ["Add some data to be exchanged between these simulations.",]
 
     class SharedDataDisjointSimulationsViolation(CommonDisjointSimulationsViolation):
         severity = Severity.WARNING
@@ -70,9 +70,7 @@ class DisjointSimulationsRule(Rule):
             return self.assemble_from_default_explanation(f", but share data {self.shared_data.name}")
 
         def format_possible_solutions(self) -> list[str]:
-            return default_possible_solutions + [
-                "Exchange the data between these simulations.",
-            ]
+            return default_possible_solutions + ["Exchange the data between these simulations.",]
 
     def check(self, graph: Graph) -> list[Violation]:
         def is_participant(node) -> bool:
@@ -130,8 +128,8 @@ class DisjointSimulationsRule(Rule):
                 if any_node in potential_home_component:
                     home_component = potential_home_component
 
-            assert home_component is not None,\
-                "Any dataless component is always in an overall component"
+            assert home_component is not None, \
+                "Any dataless component is always in an overall component."
 
             # Now, use this home component to add this dataless component to one or more data names
             related_data = filter(is_data_node, home_component)

--- a/preciceconfigchecker/rules/m2n_exchange.py
+++ b/preciceconfigchecker/rules/m2n_exchange.py
@@ -6,9 +6,9 @@ from preciceconfigchecker.violation import Violation
 
 
 class M2NExchangeRule(Rule):
-    name = "M2N Exchange Rule."
+    name = "M2N-exchange rule."
 
-    class MissingM2NEchangeViolation(Violation):
+    class MissingM2NExchangeViolation(Violation):
         """
             This class handles a participant not being part of an M2N exchange.
         """
@@ -21,9 +21,7 @@ class M2NExchangeRule(Rule):
             return f"Participant {self.participant.name} is not part of an M2N exchange."
 
         def format_possible_solutions(self) -> list[str]:
-            return [
-                f"Please create an M2N exchange between participant {self.participant.name} and another participant.",
-                f"Otherwise, please remove participant {self.participant.name} to improve readability."]
+            return [f"Please create an M2N exchange between {self.participant.name} and another participant."]
 
     class DuplicateM2NExchangeViolation(Violation):
         """
@@ -36,12 +34,12 @@ class M2NExchangeRule(Rule):
             self.participant2 = calo_nord
 
         def format_explanation(self) -> str:
-            return (f"There is more than one M2N exchange between participant {self.participant1.name} and "
-                    f"participant {self.participant2.name}.")
+            return (f"There is more than one M2N exchange between participants {self.participant1.name} and "
+                    f"{self.participant2.name}.")
 
         def format_possible_solutions(self) -> list[str]:
-            return [f"Please remove duplicate M2N exchanges between participant {self.participant1.name} and "
-                    f"participant {self.participant2.name}."]
+            return [f"Please remove duplicate M2N exchanges between {self.participant1.name} and "
+                    f"{self.participant2.name}."]
 
     def check(self, graph: Graph) -> list[Violation]:
         violations: list[Violation] = []
@@ -65,7 +63,7 @@ class M2NExchangeRule(Rule):
         # Check every participant if it gets mentioned in an M2N exchange
         for participant in participants:
             if participant not in m2n_participants:
-                violations.append(self.MissingM2NEchangeViolation(participant))
+                violations.append(self.MissingM2NExchangeViolation(participant))
 
         # Check every M2N for duplicates
         for m2n in m2ns:

--- a/preciceconfigchecker/rules/mapping.py
+++ b/preciceconfigchecker/rules/mapping.py
@@ -38,7 +38,7 @@ class MappingRule(Rule):
                 self.connecting_word = "to"
 
         def format_explanation(self) -> str:
-            out: str = (f"The participant {self.participant.name} is specifying a {self.direction.value}-mapping "
+            out: str = (f"Participant {self.participant.name} is specifying a {self.direction.value}-mapping "
                         f"{self.connecting_word} mesh {self.mesh.name}, which is his own mesh.")
             out += f"\nThe mapping is on {self.participant.name}'s own meshes, which is forbidden."
             return out
@@ -65,27 +65,24 @@ class MappingRule(Rule):
                 self.connecting_word = "to"
 
         def format_explanation(self) -> str:
-            out: str = (f"The participant {self.parent.name} is specifying a {self.direction.value}-mapping "
+            out: str = (f"Participant {self.parent.name} is specifying a {self.direction.value}-mapping "
                         f"{self.connecting_word} participant {self.stranger.name}, but the exchange in the coupling-"
                         f"scheme between them is incorrect.")
-            out += (
-                f"\nFor a {self.direction.value}-mapping, the mesh {self.mesh.name} should be used to exchange "
-                f"data and the participant specifying the {self.connecting_word}-mesh should be the "
-                f"{self.connecting_word}-participant in the exchange.")
+            out += (f"\nFor a {self.direction.value}-mapping, {self.mesh.name} should be used to exchange "
+                    f"data and the participant specifying the {self.connecting_word}-mesh should be the "
+                    f"{self.connecting_word}-participant in the exchange.")
             return out
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
             # In a 'read' mapping, the 'from' mesh is by Stranger => Stranger should be from-participant in exchange.
             if self.direction == Direction.READ:
-                out += [f"Add an exchange from participant {self.stranger.name} to participant {self.parent.name}, "
-                        f"which uses participant {self.stranger.name}'s mesh {self.mesh.name} to the coupling-scheme "
-                        f"between them."]
+                out += [f"Add an exchange from {self.stranger.name} to {self.parent.name}, which uses "
+                        f"{self.stranger.name}'s mesh {self.mesh.name} to the coupling-scheme between them."]
             # In a 'write' mapping, the 'to' mesh is by Stranger => Stranger should be to-participant in exchange.
             elif self.direction == Direction.WRITE:
-                out += [f"Add an exchange from participant {self.parent.name} to participant {self.stranger.name}, "
-                        f"which uses participant {self.stranger.name}'s mesh {self.mesh.name}, to the coupling-scheme "
-                        f"between them."]
+                out += [f"Add an exchange from {self.parent.name} to {self.stranger.name}, which uses "
+                        f"{self.stranger.name}'s mesh {self.mesh.name}, to the coupling-scheme between them."]
             return out
 
     class MissingExchangeMappingViolation(Violation):
@@ -106,10 +103,10 @@ class MappingRule(Rule):
                 self.connecting_word = "to"
 
         def format_explanation(self) -> str:
-            out: str = (f"The participant {self.parent.name} is specifying a {self.direction.value}-mapping "
+            out: str = (f"Participant {self.parent.name} is specifying a {self.direction.value}-mapping "
                         f"{self.connecting_word} participant {self.stranger.name}'s mesh {self.mesh.name}, "
                         f"but there is no exchange for it in the coupling-scheme between them.")
-            out += (f"\nFor a {self.direction.value}-mapping, the mesh {self.mesh.name} should be used to "
+            out += (f"\nFor a {self.direction.value}-mapping, {self.mesh.name} should be used to "
                     f"exchange data.")
             return out
 
@@ -117,14 +114,12 @@ class MappingRule(Rule):
             out: list[str] = []
             # In a 'read' mapping, the 'from' mesh is by Stranger => Stranger should be from-participant in exchange.
             if self.direction == Direction.READ:
-                out += [f"Add an exchange from participant {self.stranger.name} to participant {self.parent.name}, "
-                        f"which uses participant {self.stranger.name}'s mesh {self.mesh.name} to the coupling-scheme "
-                        f"between them."]
+                out = [f"Add an exchange from {self.stranger.name} to {self.parent.name}, which uses "
+                       f"{self.stranger.name}'s mesh {self.mesh.name} to the coupling-scheme between them."]
             # In a 'write' mapping, the 'to' mesh is by Stranger => Stranger should be to-participant in exchange.
             elif self.direction == Direction.WRITE:
-                out += [f"Add an exchange from participant {self.parent.name} to participant {self.stranger.name}, "
-                        f"which uses participant {self.stranger.name}'s mesh {self.mesh.name} to the coupling-scheme "
-                        f"between them."]
+                out = [f"Add an exchange from {self.parent.name} to {self.stranger.name}, which uses "
+                       f"{self.stranger.name}'s mesh {self.mesh.name} to the coupling-scheme between them."]
             return out
 
     class MissingCouplingSchemeMappingViolation(Violation):
@@ -145,15 +140,14 @@ class MappingRule(Rule):
                 self.connecting_word = "to"
 
         def format_explanation(self) -> str:
-            return (f"The participant {self.parent.name} is specifying a {self.direction.value}-mapping "
+            return (f"Participant {self.parent.name} is specifying a {self.direction.value}-mapping "
                     f"{self.connecting_word} participant {self.stranger.name}, but there does not exist a "
                     f"coupling-scheme between them.")
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
-            out += [
-                f"Create a coupling-scheme between participants {self.parent.name} and {self.stranger.name} with an "
-                f"exchange to exchange data between them."]
+            out += [f"Create a coupling-scheme between {self.parent.name} and {self.stranger.name} with an "
+                    f"exchange to exchange data between them."]
             out += ["Otherwise, please remove the mapping to improve readability."]
             return out
 
@@ -181,8 +175,8 @@ class MappingRule(Rule):
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
-            out += [f"Create an m2n-exchange between participants {self.parent.name} and {self.stranger.name}"
-                    f" to exchange data between them."]
+            out += [f"Create an m2n-exchange between {self.parent.name} and {self.stranger.name} to exchange data "
+                    f"between them."]
             out += ["Otherwise, please remove the mapping to improve readability."]
             return out
 
@@ -204,45 +198,39 @@ class MappingRule(Rule):
             self.constraint = constraint
 
         def format_explanation(self) -> str:
-            out: str = f"The participants {self.parent.name} and {self.stranger.name} are executing in parallel."
-            out += (
-                f"\nThe {self.direction.value}-mapping specified by participant {self.parent.name} on meshes "
-                f"{self.mesh_parent.name} and {self.mesh_stranger.name} with constraint=\"{self.constraint.value}\" "
-                f"is is invalid.")
-            out += (
-                "\nFor parallel participants, only mappings of the form read-consistent and write-conservative are "
-                "allowed.")
+            out: str = f"Participants {self.parent.name} and {self.stranger.name} are executing in parallel."
+            out += (f"\nThe {self.direction.value}-mapping specified by {self.parent.name} on meshes "
+                    f"{self.mesh_parent.name} and {self.mesh_stranger.name} with constraint=\"{self.constraint.value}\" "
+                    f"is is invalid.")
+            out += ("\nFor parallel participants, only mappings of the form read-consistent and write-conservative are "
+                    "allowed.")
             return out
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
             # Mapping format is "almost" correct
             if self.direction == Direction.READ and self.constraint == MappingConstraint.CONSERVATIVE:
-                out += [
-                    f"Consider changing either the direction of the mapping between participants {self.parent.name} and "
-                    f"{self.stranger.name} to direction=\"write\" or the constraint of the mapping to constraint="
-                    f"\"consistent\"."]
+                out += [f"Consider changing either the direction of the mapping between {self.parent.name} and "
+                        f"{self.stranger.name} to direction=\"write\" or the constraint of the mapping to constraint="
+                        f"\"consistent\"."]
                 out += [f"The effect of a read-conservative mapping can be achieved by moving the mapping from "
-                        f"participant {self.parent.name} to participant {self.stranger.name} and changing its direction "
-                        f"to \"write\"."]
+                        f"{self.parent.name} to {self.stranger.name} and changing its direction to \"write\"."]
                 out += [f"When moving the mapping, remember to update the <exchange .../> tag in the participants "
                         f"coupling-scheme."]
             elif self.direction == Direction.WRITE and self.constraint == MappingConstraint.CONSISTENT:
-                out += [
-                    f"Consider changing either the direction of the mapping between participants {self.parent.name} and "
-                    f"{self.stranger.name} to direction=\"read\" or the constraint of the mapping to constraint="
-                    f"\"conservative\"."]
+                out += [f"Consider changing either the direction of the mapping between {self.parent.name} and "
+                        f"{self.stranger.name} to direction=\"read\" or the constraint of the mapping to constraint="
+                        f"\"conservative\"."]
                 out += [f"The effect of a write-consistent mapping can be achieved by moving the mapping from "
-                        f"participant {self.parent.name} to participant {self.stranger.name} and changing its direction "
-                        f"to \"read\"."]
+                        f"{self.parent.name} to {self.stranger.name} and changing its direction to \"read\"."]
                 out += [f"When moving the mapping, remember to update the <exchange .../> tag in the participants "
                         f"coupling-scheme."]
             # Generic answers for arbitrary constraints
             elif self.direction == Direction.READ:
-                out += [f"Consider changing the constraint of the mapping between participants {self.parent.name} and "
+                out += [f"Consider changing the constraint of the mapping between {self.parent.name} and "
                         f"{self.stranger.name} from \"{self.constraint.value}\" to \"consistent\"."]
             elif self.direction == Direction.WRITE:
-                out += [f"Consider changing the constraint of the mapping between participants {self.parent.name} and "
+                out += [f"Consider changing the constraint of the mapping between {self.parent.name} and "
                         f"{self.stranger.name} from \"{self.constraint.value}\" to \"conservative\"."]
             return out
 
@@ -282,11 +270,10 @@ class MappingRule(Rule):
         def format_possible_solutions(self) -> list[str]:
             sol: list[str] = []
             sol += [
-                f"Either change direction=\"{self.direction.value}\" to direction=\"{self.inverse_direction.value}\""
-                f", or swap meshes {self.mesh_parent.name} and {self.mesh_stranger.name}."]
-            sol += [f"Move the mapping from participant {self.parent.name} to participant "
-                    f"{self.stranger.name}, change its direction and remember to switch the mesh used in the "
-                    f"<exchange .../> tag in their coupling scheme."]
+                f"Either change direction=\"{self.direction.value}\" to direction=\"{self.inverse_direction.value}\", "
+                f"or swap meshes {self.mesh_parent.name} and {self.mesh_stranger.name}."]
+            sol += [f"Move the mapping from {self.parent.name} to {self.stranger.name}, change its direction and "
+                    f"remember to update the mesh used in the <exchange .../> tag in their coupling scheme."]
             sol += ["Otherwise, please remove it to improve readability."]
             return sol
 
@@ -317,7 +304,7 @@ class MappingRule(Rule):
         def format_explanation(self) -> str:
             out: str = (f"Participant {self.parent.name} is specifying a {self.direction.value}-mapping "
                         f"{self.connecting_word} participant {self.stranger.name}'s mesh {self.mesh_stranger.name} "
-                        f"{self.inverse_connector} participant {self.parent.name}'s mesh {self.mesh_parent.name}.")
+                        f"{self.inverse_connector} {self.parent.name}'s mesh {self.mesh_parent.name}.")
             if self.missing_data_processing == MissingDataProcessing.READ_DATA:
                 if self.direction == Direction.WRITE:
                     out += (f"\nHowever, it seems like {self.stranger.name} does not {self.inverse_direction.value} "
@@ -386,10 +373,10 @@ class MappingRule(Rule):
                     f"does not have access to it.")
 
         def format_possible_solutions(self) -> list[str]:
-            return [f"Let participant {self.parent.name} receive mesh {self.mesh.name} from participant "
-                    f"{self.stranger.name} with the attribute api-access=\"true\".",
-                    f"Map the values from mesh {self.mesh.name} to a mesh by participant {self.parent.name}, before"
-                    f" {self.direction.value}ing them.",
+            return [f"Let {self.parent.name} receive mesh {self.mesh.name} from {self.stranger.name} with attribute "
+                    f"api-access=\"true\".",
+                    f"Map the values from mesh {self.mesh.name} to a mesh by {self.parent.name}, before "
+                    f"{self.direction.value}ing them.",
                     "Otherwise, please remove it to improve readability."]
 
     class JustInTimeMappingFormatViolation(Violation):
@@ -414,44 +401,38 @@ class MappingRule(Rule):
             self.constraint = constraint
 
         def format_explanation(self) -> str:
-            out: str = (
-                f"The just-in-time {self.direction.value}-mapping of participant {self.parent.name} {self.connecting_word} "
-                f"participant {self.stranger.name}'s mesh {self.mesh.name} is in direction="
-                f"\"{self.direction.value}\" and has constraint=\"{self.constraint.value}\", which is invalid.")
-            out += (
-                "\nCurrently, only just-in-time mappings of the form read-consistent and write-conservative are "
-                "supported.")
+            out: str = (f"The just-in-time {self.direction.value}-mapping of participant {self.parent.name} "
+                        f"{self.connecting_word} participant {self.stranger.name}'s mesh {self.mesh.name} is in direction="
+                        f"\"{self.direction.value}\" and has constraint=\"{self.constraint.value}\", which is invalid.")
+            out += ("\nCurrently, only just-in-time mappings of the form read-consistent and write-conservative are "
+                    "supported.")
             return out
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
             # Mapping format is "almost" correct
             if self.direction == Direction.READ and self.constraint == MappingConstraint.CONSERVATIVE:
-                out += [
-                    f"Consider changing either the direction of the mapping between participants {self.parent.name} and "
-                    f"{self.stranger.name} to direction=\"write\" or the constraint of the mapping to constraint="
-                    f"\"consistent\"."]
+                out += [f"Consider changing either the direction of the mapping between {self.parent.name} and "
+                        f"{self.stranger.name} to direction=\"write\" or the constraint of the mapping to constraint="
+                        f"\"consistent\"."]
                 out += [f"The effect of a read-conservative mapping can be achieved by moving the mapping from "
-                        f"participant {self.parent.name} to participant {self.stranger.name} and changing its direction "
-                        f"to \"write\"."]
-                out += [f"When moving the mapping, remember to update the <exchange .../> tag in the participants "
-                        f"coupling-scheme."]
-            elif self.direction == Direction.WRITE and self.constraint == MappingConstraint.CONSISTENT:
+                        f"{self.parent.name} to {self.stranger.name} and changing its direction to \"write\"."]
                 out += [
-                    f"Consider changing either the direction of the mapping between participants {self.parent.name} and "
-                    f"{self.stranger.name} to direction=\"read\" or the constraint of the mapping to constraint="
-                    f"\"conservative\"."]
+                    f"When moving the mapping, remember to update the <exchange .../> tag in their coupling-scheme."]
+            elif self.direction == Direction.WRITE and self.constraint == MappingConstraint.CONSISTENT:
+                out += [f"Consider changing either the direction of the mapping between {self.parent.name} and "
+                        f"{self.stranger.name} to direction=\"read\" or the constraint of the mapping to constraint="
+                        f"\"conservative\"."]
                 out += [f"The effect of a write-consistent mapping can be achieved by moving the mapping from "
-                        f"participant {self.parent.name} to participant {self.stranger.name} and changing its direction "
-                        f"to \"read\"."]
-                out += [f"When moving the mapping, remember to update the <exchange .../> tag in the participants "
-                        f"coupling-scheme."]
+                        f"{self.parent.name} to {self.stranger.name} and changing its direction to \"read\"."]
+                out += [
+                    f"When moving the mapping, remember to update the <exchange .../> tag in their coupling-scheme."]
             # Generic answers for arbitrary constraints
             elif self.direction == Direction.READ:
-                out += [f"Consider changing the constraint of the mapping between participants {self.parent.name} and "
+                out += [f"Consider changing the constraint of the mapping between {self.parent.name} and "
                         f"{self.stranger.name} from \"{self.constraint.value}\" to \"consistent\"."]
             elif self.direction == Direction.WRITE:
-                out += [f"Consider changing the constraint of the mapping between participants {self.parent.name} and "
+                out += [f"Consider changing the constraint of the mapping between {self.parent.name} and "
                         f"{self.stranger.name} from \"{self.constraint.value}\" to \"conservative\"."]
             return out
 
@@ -480,18 +461,16 @@ class MappingRule(Rule):
             out: str = (f"The just-in-time {self.direction.value}-mapping of participant {self.parent.name} "
                         f"{self.connecting_word} participant {self.stranger.name} and mesh {self.mesh.name} is in "
                         f"the wrong direction.")
-            out += (
-                f"\nIn just-in-time{self.direction.value}-mappings, the {self.connecting_word}=\"mesh\" has to "
-                f"be on a stranger participants mesh.")
+            out += (f"\nIn just-in-time{self.direction.value}-mappings, the {self.connecting_word}=\"mesh\" has to "
+                    f"be on a stranger participants mesh.")
             return out
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
             out += [f"Change direction=\"{self.direction.value}\" to direction=\"{self.inverse_direction.value}\"."]
-            out += [f"Move the mapping from participant {self.parent.name} to participant "
-                    f"{self.stranger.name} and change its direction and remember to switch the mesh used in the "
-                    f"<exchange .../> tag in their coupling scheme."]
-            out += [f"Otherwise, change the {self.connecting_word}-mesh to a mesh by participant {self.stranger.name}."]
+            out += [f"Move the mapping from {self.parent.name} to {self.stranger.name}, change its direction and "
+                    f"remember to switch the mesh used in the <exchange .../> tag in their coupling scheme."]
+            out += [f"Otherwise, change the {self.connecting_word}-mesh to a mesh by {self.stranger.name}."]
             return out
 
     class JustInTimeMappingFormatDirectionViolation(Violation):
@@ -521,27 +500,24 @@ class MappingRule(Rule):
                 f"The just-in-time {self.direction.value}-mapping with constraint \"{self.constraint.value}\" between "
                 f"participant {self.parent.name} and participant {self.stranger.name}'s mesh {self.mesh.name} has an "
                 f"invalid format and is in the wrong direction.")
-            out += (
-                f"\nCurrently, only the formats \"write-conservative\" and \"read-consistent\" are implemented for "
-                f"just-in-time mappings.")
-            out += (
-                f"\nIn just-in-time {self.direction.value}-mappings, the {self.connecting_word}=\"mesh\" has to "
-                f"be on a stranger participants mesh.")
+            out += (f"\nCurrently, only the formats \"write-conservative\" and \"read-consistent\" are implemented for "
+                    f"just-in-time mappings.")
+            out += (f"\nIn just-in-time {self.direction.value}-mappings, the {self.connecting_word}=\"mesh\" has to "
+                    f"be on a stranger participants mesh.")
             return out
 
         def format_possible_solutions(self) -> list[str]:
             out: list[str] = []
             out += [f"Change direction=\"{self.direction.value}\" to direction=\"{self.inverse_direction.value}\"."]
-            out += [f"Move the mapping from participant {self.parent.name} to participant "
-                    f"{self.stranger.name}, change its direction and remember to switch the mesh used in the "
-                    f"<exchange .../> tag in their coupling scheme."]
+            out += [f"Move the mapping from {self.parent.name} to {self.stranger.name}, change its direction and "
+                    f"remember to switch the mesh used in the <exchange .../> tag in their coupling scheme."]
             if self.direction == Direction.WRITE:
-                out += [f"Please update the constraint of the mapping between participants {self.parent.name} and "
+                out += [f"Please update the constraint of the mapping between {self.parent.name} and "
                         f"{self.stranger.name} from \"{self.constraint.value}\" to \"conservative\"."]
             elif self.direction == Direction.READ:
-                out += [f"Please update the constraint of the mapping between participants {self.parent.name} and "
+                out += [f"Please update the constraint of the mapping between {self.parent.name} and "
                         f"{self.stranger.name} from \"{self.constraint.value}\" to \"consistent\"."]
-            out += [f"Otherwise, change the {self.connecting_word}-mesh to a mesh by participant {self.stranger.name}."]
+            out += [f"Otherwise, change the {self.connecting_word}-mesh to a mesh by {self.stranger.name}."]
             return out
 
     class JustInTimeMappingMethodViolation(Violation):
@@ -566,12 +542,11 @@ class MappingRule(Rule):
             self.method = method
 
         def format_explanation(self) -> str:
-            out: str = (
-                f"The just-in-time {self.direction.value}-mapping of participant {self.parent.name} {self.connecting_word} "
-                f"{self.stranger.name}'s mesh {self.mesh.name} has mapping-method \"{self.method.value}\", which is invalid.")
-            out += (
-                "\nCurrently, only just-in-time mappings with methods \"nearest-neighbor\", \"rbf-pum-direct\" and "
-                "\"rbf\" are supported.")
+            out: str = (f"The just-in-time {self.direction.value}-mapping of participant {self.parent.name} "
+                        f"{self.connecting_word} {self.stranger.name}'s mesh {self.mesh.name} has mapping-method "
+                        f"\"{self.method.value}\", which is invalid.")
+            out += (f"\nCurrently, only just-in-time mappings with methods \"nearest-neighbor\", \"rbf-pum-direct\" and"
+                    " \"rbf\" are supported.")
             return out
 
         def format_possible_solutions(self) -> list[str]:
@@ -611,10 +586,10 @@ class MappingRule(Rule):
                 elif self.direction == Direction.READ:
                     out += (f"\nHowever, it seems like {self.parent.name} does not {self.direction.value} "
                             f"{self.connecting_word} {self.mesh.name}.")
-                elif self.missing_data_processing == MissingDataProcessing.WRITE_DATA:
-                    if self.direction == Direction.WRITE:
-                        out += (f"\nHowever, it seems like {self.parent.name} does not {self.inverse_direction.value} "
-                                f"{self.inverse_connector} {self.mesh.name}.")
+            elif self.missing_data_processing == MissingDataProcessing.WRITE_DATA:
+                if self.direction == Direction.WRITE:
+                    out += (f"\nHowever, it seems like {self.parent.name} does not {self.inverse_direction.value} "
+                            f"{self.inverse_connector} {self.mesh.name}.")
                 elif self.direction == Direction.READ:
                     out += (f"\nHowever, it seems like {self.stranger.name} does not {self.direction.value} "
                             f"{self.connecting_word} {self.mesh.name}.")

--- a/preciceconfigchecker/rules/provide_mesh.py
+++ b/preciceconfigchecker/rules/provide_mesh.py
@@ -20,10 +20,10 @@ class ProvideMeshRule(Rule):
             self.mesh = mesh
 
         def format_explanation(self) -> str:
-            return f"The mesh {self.mesh.name} does not get provided by any participant."
+            return f"Mesh {self.mesh.name} does not get provided by any participant."
 
         def format_possible_solutions(self) -> list[str]:
-            return [f"Please let any participant provide the mesh {self.mesh.name}.",
+            return [f"Please let any participant provide {self.mesh.name}.",
                     "Otherwise, please remove it to improve readability."]
 
     class RepeatedlyClaimedMeshViolation(Violation):
@@ -46,7 +46,7 @@ class ProvideMeshRule(Rule):
             self.names += participants_s[-1].name
 
         def format_explanation(self) -> str:
-            return f"The mesh {self.mesh.name} is provided by participants {self.names}."
+            return f"Mesh {self.mesh.name} is provided by participants {self.names}."
 
         def format_possible_solutions(self) -> list[str]:
             return [f"Ensure that only one participant provides {self.mesh.name}."]

--- a/tests/m2n-exchange/m2n-exchange_test.py
+++ b/tests/m2n-exchange/m2n-exchange_test.py
@@ -21,7 +21,7 @@ def test_m2n_exchange():
                 n_instigator = node
 
     violations_expected = [
-        e.MissingM2NEchangeViolation(n_alligator),
+        e.MissingM2NExchangeViolation(n_alligator),
         e.DuplicateM2NExchangeViolation(n_generator, n_propagator),
         d.FullyDisjointSimulationsViolation(frozenset([
             frozenset([n_generator, n_propagator, n_instigator]),

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -77,7 +77,7 @@ def test_mapping():
 
         m.MappingMissingDataProcessingViolation(p_propagator, p_generator, m_propagator, m_generator, Direction.WRITE,
                                                 mdp.READ_DATA),
-        mn.MissingM2NEchangeViolation(p_incinerator),
+        mn.MissingM2NExchangeViolation(p_incinerator),
 
         d.DataNotExchangedViolation(d_color, p_generator, p_alligator),
 


### PR DESCRIPTION
Many `format_explanation` and `format_possible_solutions` had multiple mentions that some participant or mesh is a mesh.

I think that mentioning only once, that X is a participant, makes the output more readable, as it is shorter and contains less redundant information.

E.g.:
Before:
`The participant X is specifying a read-mapping from participant Y's mesh Y-Mesh,  but there is no exchange for it in the coupling-scheme between them.
For a read-mapping, the mesh Y-mesh should be used to exchange data.`
`==> Add an exchange from participant Y to participant X, which uses participant Y's mesh Y-Mesh to the coupling-scheme between them.`

Now:
`Participant X is specifying a read-mapping from participant Y's mesh Y-Mesh,  but there is no exchange for it in the coupling-scheme between them.
For a read-mapping, Y-mesh should be used to exchange data.`
`==> Add an exchange from Y to X, which uses Y's mesh Y-Mesh to the coupling-scheme between them.`