### PR TITLE
Fix bug: Missing mapping not recognized

### DIFF
--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -1,6 +1,6 @@
 from networkx import Graph
 from precice_config_graph.nodes import CouplingSchemeNode, MultiCouplingSchemeNode, ParticipantNode, ExchangeNode, \
-    MeshNode, MappingNode, Direction
+    MeshNode, MappingNode, Direction, DataNode
 
 from preciceconfigchecker.rule import Rule
 from preciceconfigchecker.severity import Severity
@@ -18,7 +18,8 @@ class CouplingSchemeMappingRule(Rule):
         """
         severity = Severity.ERROR
 
-        def __init__(self, from_participant: ParticipantNode, to_participant: ParticipantNode, exchange_mesh: MeshNode):
+        def __init__(self, from_participant: ParticipantNode, to_participant: ParticipantNode, exchange_mesh: MeshNode,
+                     data: DataNode):
             self.from_participant = from_participant
             self.to_participant = to_participant
             self.exchange_mesh = exchange_mesh
@@ -38,9 +39,10 @@ class CouplingSchemeMappingRule(Rule):
                 self.mesh_owner = to_participant
                 self.from_string = f"from a mesh provided by {from_participant.name}"
                 self.to_string = f"to {self.exchange_mesh.name}"
+            self.data = data
 
         def format_explanation(self) -> str:
-            return (f"The exchange belonging to the coupling-scheme between participants "
+            return (f"The exchange of data {self.data.name} belonging to the coupling-scheme between participants "
                     f"{self.from_participant.name} and {self.to_participant.name} using {self.mesh_owner.name}'s "
                     f"mesh {self.exchange_mesh.name} is missing a mapping.")
 
@@ -58,7 +60,8 @@ class CouplingSchemeMappingRule(Rule):
         """
         severity = Severity.DEBUG
 
-        def __init__(self, from_participant: ParticipantNode, to_participant: ParticipantNode, exchange_mesh: MeshNode):
+        def __init__(self, from_participant: ParticipantNode, to_participant: ParticipantNode, exchange_mesh: MeshNode,
+                     data: DataNode):
             self.from_participant = from_participant
             self.to_participant = to_participant
             self.exchange_mesh = exchange_mesh
@@ -74,9 +77,10 @@ class CouplingSchemeMappingRule(Rule):
                 self.mapper = from_participant
                 self.non_mapper = to_participant
                 self.mesh_owner = to_participant
+            self.data = data
 
         def format_explanation(self) -> str:
-            out: str = (f"The exchange belonging to the coupling-scheme between participants "
+            out: str = (f"The exchange of data {self.data.name} belonging to the coupling-scheme between participants "
                         f"{self.from_participant.name} and {self.to_participant.name} using {self.mesh_owner.name}'s "
                         f"mesh {self.exchange_mesh.name} does not have a mapping.")
             out += (f"\nThis is valid, because {self.mapper.name} has api-access to {self.non_mapper.name}'s "
@@ -106,6 +110,7 @@ class CouplingSchemeMappingRule(Rule):
                 to_participant = exchange.to_participant
                 from_meshes = from_participant.provide_meshes
                 to_meshes = to_participant.provide_meshes
+                data:DataNode = exchange.data
 
                 # from-participant writes data to from-mesh, exchanges it to to-participant, who maps it to his own
                 # mesh and then reads from it => READ-mapping by to-participant required, or api-access to from-mesh
@@ -116,13 +121,13 @@ class CouplingSchemeMappingRule(Rule):
                     # Only add a violation if no correct mapping exists
 
                     if exchange.data.name == "Displacement":
-                        print("\n",has_correct_mapping)
+                        print("\n", has_correct_mapping)
                         for mapping in to_participant.mappings:
                             print("mapping:\n", "parent", mapping.parent_participant.name, "from",
                                   mapping.from_mesh.name,
                                   "to", mapping.to_mesh.name)
                     elif exchange.data.name == "Velocity":
-                        print("\n",has_correct_mapping)
+                        print("\n", has_correct_mapping)
                         for mapping in to_participant.mappings:
                             print("mapping:\n", "parent", mapping.parent_participant.name, "from",
                                   mapping.from_mesh.name,
@@ -134,11 +139,11 @@ class CouplingSchemeMappingRule(Rule):
                             violations.append(
                                 self.MissingMappingAPIAccessCouplingSchemeViolation(from_participant,
                                                                                     to_participant,
-                                                                                    exchange_mesh))
+                                                                                    exchange_mesh,data))
                         else:
                             violations.append(
                                 self.MissingMappingCouplingSchemeViolation(from_participant, to_participant,
-                                                                           exchange_mesh))
+                                                                           exchange_mesh,data))
                 # from-participant writes data to own mesh, maps it to to-mesh, exchanges it to to-participant, who
                 # reads from it => WRITE-mapping by from-participant required, or api-access to to-mesh
                 elif exchange_mesh in to_meshes:
@@ -152,11 +157,11 @@ class CouplingSchemeMappingRule(Rule):
                             violations.append(
                                 self.MissingMappingAPIAccessCouplingSchemeViolation(from_participant,
                                                                                     to_participant,
-                                                                                    exchange_mesh))
+                                                                                    exchange_mesh,data))
                         else:
                             violations.append(
                                 self.MissingMappingCouplingSchemeViolation(from_participant, to_participant,
-                                                                           exchange_mesh))
+                                                                           exchange_mesh, data))
 
         return violations
 

--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -98,6 +98,8 @@ class CouplingSchemeMappingRule(Rule):
             # Check for all exchanges, whether a mapping exists between first and second (in the correct direction)
             exchanges: list[ExchangeNode] = coupling.exchanges
             for exchange in exchanges:
+                print("exchange:\ndata:", exchange.data.name, "mesh", exchange.mesh.name, "from:",
+                      exchange.from_participant.name, "to:", exchange.to_participant.name)
                 # Check whose mesh gets used
                 exchange_mesh = exchange.mesh
                 from_participant = exchange.from_participant
@@ -112,6 +114,20 @@ class CouplingSchemeMappingRule(Rule):
                         mapping_fits_exchange(mapping, Direction.READ, from_participant, to_participant,
                                               exchange_mesh) for mapping in to_participant.mappings)
                     # Only add a violation if no correct mapping exists
+
+                    if exchange.data.name == "Displacement":
+                        print("\n",has_correct_mapping)
+                        for mapping in to_participant.mappings:
+                            print("mapping:\n", "parent", mapping.parent_participant.name, "from",
+                                  mapping.from_mesh.name,
+                                  "to", mapping.to_mesh.name)
+                    elif exchange.data.name == "Velocity":
+                        print("\n",has_correct_mapping)
+                        for mapping in to_participant.mappings:
+                            print("mapping:\n", "parent", mapping.parent_participant.name, "from",
+                                  mapping.from_mesh.name,
+                                  "to", mapping.to_mesh.name)
+
                     if not has_correct_mapping:
                         if has_api_access(to_participant, exchange_mesh):
                             # If the participant has api-access, add a debug-violation
@@ -176,10 +192,15 @@ def mapping_fits_exchange(mapping: MappingNode, direction: Direction, from_parti
         # For direction-write, the mesh used in the exchange needs to be by to-participant
         if exchange_mesh not in to_participant.provide_meshes:
             return False
+        if exchange_mesh != mapping.to_mesh:
+            return False
     elif direction == Direction.READ:
         # For direction-read, the mesh used in the exchange needs to be by from-participant
         if exchange_mesh not in from_participant.provide_meshes:
             return False
+        elif exchange_mesh != mapping.from_mesh:
+            return False
+
     return True
 
 

--- a/preciceconfigchecker/rules/coupling_scheme_mapping.py
+++ b/preciceconfigchecker/rules/coupling_scheme_mapping.py
@@ -102,15 +102,13 @@ class CouplingSchemeMappingRule(Rule):
             # Check for all exchanges, whether a mapping exists between first and second (in the correct direction)
             exchanges: list[ExchangeNode] = coupling.exchanges
             for exchange in exchanges:
-                print("exchange:\ndata:", exchange.data.name, "mesh", exchange.mesh.name, "from:",
-                      exchange.from_participant.name, "to:", exchange.to_participant.name)
                 # Check whose mesh gets used
                 exchange_mesh = exchange.mesh
                 from_participant = exchange.from_participant
                 to_participant = exchange.to_participant
                 from_meshes = from_participant.provide_meshes
                 to_meshes = to_participant.provide_meshes
-                data:DataNode = exchange.data
+                data: DataNode = exchange.data
 
                 # from-participant writes data to from-mesh, exchanges it to to-participant, who maps it to his own
                 # mesh and then reads from it => READ-mapping by to-participant required, or api-access to from-mesh
@@ -119,31 +117,17 @@ class CouplingSchemeMappingRule(Rule):
                         mapping_fits_exchange(mapping, Direction.READ, from_participant, to_participant,
                                               exchange_mesh) for mapping in to_participant.mappings)
                     # Only add a violation if no correct mapping exists
-
-                    if exchange.data.name == "Displacement":
-                        print("\n", has_correct_mapping)
-                        for mapping in to_participant.mappings:
-                            print("mapping:\n", "parent", mapping.parent_participant.name, "from",
-                                  mapping.from_mesh.name,
-                                  "to", mapping.to_mesh.name)
-                    elif exchange.data.name == "Velocity":
-                        print("\n", has_correct_mapping)
-                        for mapping in to_participant.mappings:
-                            print("mapping:\n", "parent", mapping.parent_participant.name, "from",
-                                  mapping.from_mesh.name,
-                                  "to", mapping.to_mesh.name)
-
                     if not has_correct_mapping:
                         if has_api_access(to_participant, exchange_mesh):
                             # If the participant has api-access, add a debug-violation
                             violations.append(
                                 self.MissingMappingAPIAccessCouplingSchemeViolation(from_participant,
                                                                                     to_participant,
-                                                                                    exchange_mesh,data))
+                                                                                    exchange_mesh, data))
                         else:
                             violations.append(
                                 self.MissingMappingCouplingSchemeViolation(from_participant, to_participant,
-                                                                           exchange_mesh,data))
+                                                                           exchange_mesh, data))
                 # from-participant writes data to own mesh, maps it to to-mesh, exchanges it to to-participant, who
                 # reads from it => WRITE-mapping by from-participant required, or api-access to to-mesh
                 elif exchange_mesh in to_meshes:
@@ -157,7 +141,7 @@ class CouplingSchemeMappingRule(Rule):
                             violations.append(
                                 self.MissingMappingAPIAccessCouplingSchemeViolation(from_participant,
                                                                                     to_participant,
-                                                                                    exchange_mesh,data))
+                                                                                    exchange_mesh, data))
                         else:
                             violations.append(
                                 self.MissingMappingCouplingSchemeViolation(from_participant, to_participant,

--- a/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
+++ b/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
@@ -37,11 +37,11 @@ def test_coupling_scheme_mapping():
 
     violations_expected = [
 
-        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator),
+        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator,d_color),
 
-        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator),
+        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator,d_color),
 
-        c.MissingMappingAPIAccessCouplingSchemeViolation(p_alligator, p_instigator, m_alligator),
+        c.MissingMappingAPIAccessCouplingSchemeViolation(p_alligator, p_instigator, m_alligator,d_color),
 
         d.SharedDataDisjointSimulationsViolation(d_color, frozenset([frozenset([p_generator, p_propagator, p_elevator]),
                                                                      frozenset([p_alligator, p_instigator])])),

--- a/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
+++ b/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
@@ -37,11 +37,11 @@ def test_coupling_scheme_mapping():
 
     violations_expected = [
 
-        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator,d_color),
+        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator, d_color),
 
-        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator,d_color),
+        c.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_propagator, d_color),
 
-        c.MissingMappingAPIAccessCouplingSchemeViolation(p_alligator, p_instigator, m_alligator,d_color),
+        c.MissingMappingAPIAccessCouplingSchemeViolation(p_alligator, p_instigator, m_alligator, d_color),
 
         d.SharedDataDisjointSimulationsViolation(d_color, frozenset([frozenset([p_generator, p_propagator, p_elevator]),
                                                                      frozenset([p_alligator, p_instigator])])),

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -85,11 +85,11 @@ def test_mapping():
 
         d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
 
-        csm.MissingMappingCouplingSchemeViolation(p_propagator, p_generator, m_propagator),
+        csm.MissingMappingCouplingSchemeViolation(p_propagator, p_generator, m_propagator,d_color),
 
-        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator),
+        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator,d_color),
 
-        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator)
+        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator,d_color)
     ]
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -85,11 +85,11 @@ def test_mapping():
 
         d.DataNotExchangedViolation(d_color, p_instigator, p_elevator),
 
-        csm.MissingMappingCouplingSchemeViolation(p_propagator, p_generator, m_propagator,d_color),
+        csm.MissingMappingCouplingSchemeViolation(p_propagator, p_generator, m_propagator, d_color),
 
-        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator,d_color),
+        csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator, d_color),
 
-        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator,d_color)
+        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator, d_color)
     ]
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)


### PR DESCRIPTION
Before, it was not checked thoroughly enough, whether a correct mapping exists. Other mappings were also counted as correct, if they were specified by the required participant, but not using the correct mesh.

Now, the mesh in an exchange is also used in the check whether a mapping is correct or not.

Bonus implementation: Now the exchange is identified better, by also mentioning which data is exchanged. 
before, multiple exchanges with the same mesh, from and to participants were not distinguishable