### PR TITLE
Receive mesh rule

### DIFF
--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -79,7 +79,7 @@ If neither is satisfied, the participant has no permission to read from or write
 
 ## (5) `TODO` Participant reads from/writes to mesh, but nobody writes to/reads from it
 
-If a participant reads data from a mesh, then someone should write it beforehand.<br>
+If a participant reads data from a mesh, then someone should write it beforehand.
 Similarly, if a participant writes data to a mesh, then someone should read from it later on.
 
 - `severity`: `error`
@@ -139,11 +139,11 @@ to Stranger. Analogously, this also works to achieve a `write-consistent` mappin
 
 ### JIT mapping is in the wrong direction
 
-If the direction is `read`, then the JIT mapping needs to have the tag `from="..."`. If it instead has the tag
+If the direction is `read`, then the JIT mapping requires the tag `from="..."`. If it instead has the tag
 `to="..."`,
 then direction and tag don't fit and the mapping is in the wrong direction.
 
-Similarly, a JIT `write`-mapping needs to have the tag `to="..."`, otherwise its direction is wrong.
+Similarly, a JIT `write`-mapping requires the tag `to="..."`, otherwise its direction is wrong.
 
 - `severity`: `error`
 
@@ -196,7 +196,7 @@ In order for the data-exchange to work, both participants have to exchange data 
 
 ### Participants of mapping have no coupling scheme
 
-In order for the exchange to function properly, both participants have to exchange data via a coupling scheme.
+In order for the exchange to function properly, both participants need to exchange data via a coupling scheme.
 
 - `severity`: `error`
 
@@ -221,18 +221,11 @@ otherwise, there exists no correct data-exchange between the participants.
 
 ### Mapping is between the same participant
 
-Both meshes mentioned in the mapping get provided by the same participant.
+Both meshes mentioned in the mapping is provided by the same participant.
 
 - `severity`: `error`
 
-## (9) `TODO` Coupling scheme without mapping
-
-To ensure that exchanged data between one participant and its mesh to another participant and its mesh, a mapping has
-to be defined.
-
-- `severity`: `error`
-
-## (10) Data rules
+## (9) Data rules
 
 A data element in a preCICE needs to be mentioned at many locations to finally allow it to be utilized by one or more
 participants.
@@ -243,7 +236,7 @@ After declaration, data has to be:
 - read by a participant (or read through other means, e.g., of immediate export)
 - exchanged in a coupling scheme if it gets written and read by different participants.
 
-All other cases get checked here (minus the ones that get handled by `precice-tools check`).
+All other cases are checked here (minus the ones that get handled by `precice-tools check`).
 
 Using, reading or writing data without the respective other tags is not as severe an error, as this data element is
 likely not used in the simulation yet, due to multiple tags missing.
@@ -252,26 +245,26 @@ For the exact implementation, see `rules/data_use_read_write.py`.
 
 ### Data gets used in a mesh, read and written by different participants, but not exchanged
 
-The data element does not get exchanged between the participants which are accessing the data.
+The data element is not exchanged between the participants which are accessing the data.
 
 - `severity`: `error`
 
 ### Data gets used but not written or read
 
-The data element gets used in a mesh, but no participant is reading or writing it.
+The data element is used in a mesh, but no participant is reading or writing it.
 
 - `severity`: `warning`
 
 ### Data gets used and read, but not written
 
-The data element gets used in a mesh and read by a participant (or other ways of acquiring the data), but no participant
+The data element is used in a mesh and read by a participant (or other ways of acquiring the data), but no participant
 is writing the data.
 
 - `severity`: `error`
 
 ### Data gets used and written, but not read
 
-The data element gets used in a mesh and written by a participant, but nobody is reading it (or acquiring the data
+The data element is used in a mesh and written by a participant, but nobody is reading it (or acquiring the data
 through other means).
 
 - `severity`: `warning`
@@ -282,16 +275,15 @@ The data element gets declared but not used in a mesh, read or written by any pa
 
 - `severity`: `warning`
 
-## (11) `TODO` Unused mesh
+## (10) `TODO` Unused mesh
 
-A participant can provide a mesh to another participant, who receives it but does not use it.
-This means that the mesh is not used in any coupling scheme.
+A mesh is not used if no participant writes/reads data to/from it.
 
 This does not necessarily cause the simulation to malfunction or misbehave.
 
 - `severity`: `warning`
 
-## (12) Disjoint simulations
+## (11) Disjoint simulations
 
 A simulation between participants A and B and a second one between participants C and D can run simultaneously without
 using any of the coupling features of preCICE.
@@ -313,7 +305,7 @@ might be an oversight here and will therefore be warned about.
 
 - `severity`: `warning`
 
-## (13) A mesh must be provided by exactly one participant
+## (12) A mesh must be provided by exactly one participant
 
 Any mesh defined in the configuration must be provided by exactly one participant.
 Only then can the mesh be used in mappings, exchanges et cetera.
@@ -330,7 +322,7 @@ A mesh that gets mentioned in an arbitrary tag in the config gets provided by mu
 
 - `severity`: `error`
 
-## (14) Exchange in coupling scheme leads to mapping or api-access
+## (13) Exchange in coupling scheme leads to mapping or api-access
 
 If two participants define a coupling scheme between them, then they need a mapping or api-access to exchange data.
 
@@ -352,5 +344,24 @@ If `A` and `B` do not fulfill the criteria explained above, a violation will be 
 
 If `A` or `B` does have api-access to the correct mesh, it might still lead to an error in the simulation.
 However, as this is a valid use-case, only in debug mode will a warning be displayed.
+
+- `severity`:`debug`
+
+## (14) Received mesh must be used
+
+If participants receive a mesh, then they should use it.
+
+### Unused receive mesh
+
+If a participant receives a mesh without api-access, then they need to specify a mapping to use it.
+If they receive it with api-access, then they can write/read directly to/from it.
+
+- `severity`:`warning`
+
+### API-access with mapping
+
+If a participant receives a mesh _with_ api-access, then they do not have to specify a mapping to use it,
+as they can operate directly on it.
+However, if they still map to their own meshes, then this is not an error per se, but might not be wanted.
 
 - `severity`:`debug`

--- a/preciceconfigchecker/rules/receive_mesh.py
+++ b/preciceconfigchecker/rules/receive_mesh.py
@@ -74,8 +74,9 @@ class ReceiveMeshRule(Rule):
                         if not mapping.just_in_time and receive_mesh.api_access:
                             violations.append(self.MappedAPIAccessReceiveMesh(participant, mesh))
 
+                # No need to check if mesh has been used already
                 # These are only valid if the participant has api-access:
-                if receive_mesh.api_access:
+                if receive_mesh.api_access and not used:
                     for read_data in participant.read_data:
                         if read_data.mesh == mesh:
                             used = True

--- a/preciceconfigchecker/rules/receive_mesh.py
+++ b/preciceconfigchecker/rules/receive_mesh.py
@@ -1,0 +1,122 @@
+import networkx as nx
+from networkx import Graph
+from precice_config_graph.nodes import ParticipantNode, MeshNode, ReceiveMeshNode, Direction
+
+from preciceconfigchecker.rule import Rule
+from preciceconfigchecker.rule_utils import format_list
+from preciceconfigchecker.severity import Severity
+from preciceconfigchecker.violation import Violation
+
+
+class ReceiveMeshRule(Rule):
+    name = "Receive mesh."
+
+    class UnusedReceiveMesh(Violation):
+        """
+            This class handles a participant receiving a mesh, without using it.
+        """
+        severity = Severity.WARNING
+
+        def __init__(self, participant: ParticipantNode, mesh: MeshNode):
+            self.participant = participant
+            self.mesh = mesh
+
+        def format_explanation(self) -> str:
+            return f"Participant {self.participant.name} is receiving mesh {self.mesh.name}, without using it."
+
+        def format_possible_solutions(self) -> list[str]:
+            return [f"Please let {self.participant.name} use {self.mesh.name}, by mapping it to a mesh provided by "
+                    f"{self.participant.name} or operating on it with api-access.",
+                    "Otherwise, please remove it to improve readability."]
+
+    class MappedAPIAccessReceiveMesh(Violation):
+        """
+            This class handles a participant receiving a mesh with api-access, but specifying a mapping on it.
+            As this is unusual, a violation will be shown in debug mode.
+        """
+        severity = Severity.DEBUG
+
+        def __init__(self, participant: ParticipantNode, mesh: MeshNode):
+            self.participant = participant
+            self.mesh = mesh
+
+        def format_explanation(self) -> str:
+            return (f"Participant {self.participant.name} is receiving mesh {self.mesh.name}, with api-access, "
+                    f"but is specifying a mapping on it."
+                    f"\nThis is valid, but unusual.")
+
+        def format_possible_solutions(self) -> list[str]:
+            return [f"With api-access, {self.participant.name} can directly operate on {self.mesh.name}."]
+
+    def check(self, graph: Graph) -> list[Violation]:
+        violations: list[Violation] = []
+        participants: list[ParticipantNode] = get_participants(graph)
+        # Check all participants for their receive-meshes
+        for participant in participants:
+            receive_meshes: list[ReceiveMeshNode] = participant.receive_meshes
+            # Check all meshes they receive
+            for receive_mesh in receive_meshes:
+                used: bool = False
+                mesh: MeshNode = receive_mesh.mesh
+                # Check if they use the receive-mesh:
+                # A receive-mesh can be used by reading data from it, writing data to it, exporting it,
+                # using an action on it, tracking it with a watchpoint/-integral
+                if len(participant.exports) > 0:
+                    used = True
+                # These are only valid if they have api-access:
+                if receive_mesh.api_access:
+                    for read_data in participant.read_data:
+                        if read_data.mesh == mesh:
+                            used = True
+                    for write_data in participant.write_data:
+                        if write_data.mesh == mesh:
+                            used = True
+                    for action in participant.actions:
+                        if action.mesh == mesh:
+                            used = True
+                    for watchpoint in participant.watchpoints:
+                        if watchpoint.mesh == mesh:
+                            used = True
+                    for watch_integral in participant.watch_integrals:
+                        if watch_integral.mesh == mesh:
+                            used = True
+                    # Even with api-access, participants can still have a regular mapping
+                    for mapping in participant.mappings:
+                        if not mapping.just_in_time:
+                            if mapping.to_mesh == mesh or mapping.from_mesh == mesh:
+                                used = True
+                                violations.append(self.MappedAPIAccessReceiveMesh(participant, mesh))
+                        # if mapping.direction == Direction.READ:
+                        #     # In a regular mapping, the to-mesh must not be None
+                        #     # If it is None, then the mapping is a just-in-time mapping
+                        #     if mapping.from_mesh == mesh and mapping.to_mesh is not None:
+                        #         used = True
+                        #         violations.append(self.MappedAPIAccessReceiveMesh(participant, mesh))
+                        # elif mapping.direction == Direction.WRITE:
+                        #     if mapping.to_mesh == mesh and mapping.from_mesh is not None:
+                        #         used = True
+                        #         violations.append(self.MappedAPIAccessReceiveMesh(participant, mesh))
+
+                # If they don't have api-access, they need a mapping first
+                else:
+                    for mapping in participant.mappings:
+                        if mapping.to_mesh == mesh or mapping.from_mesh == mesh:
+                            used = True
+
+                if not used:
+                    violations.append(self.UnusedReceiveMesh(participant, mesh))
+
+        return violations
+
+
+def get_participants(graph: Graph) -> list[ParticipantNode]:
+    """
+        This method returns all participant nodes of the given graph.
+        :param graph: The graph to get the participants from.
+        :return: All participant nodes of the given graph.
+    """
+    participants: list[ParticipantNode] = []
+    for node in graph.nodes():
+        if isinstance(node, ParticipantNode):
+            participants.append(node)
+    return participants

--- a/preciceconfigchecker/rules_processing.py
+++ b/preciceconfigchecker/rules_processing.py
@@ -3,7 +3,7 @@ from networkx import Graph
 import preciceconfigchecker.color as c
 from preciceconfigchecker.rule import Rule
 from preciceconfigchecker.rules import missing_coupling, missing_exchange, data_use_read_write, compositional_coupling, \
-    mapping, m2n_exchange, disjoint_simulations, provide_mesh, coupling_scheme_mapping
+    mapping, m2n_exchange, disjoint_simulations, provide_mesh, coupling_scheme_mapping, receive_mesh
 from preciceconfigchecker.severity import Severity
 from preciceconfigchecker.violation import Violation
 
@@ -16,7 +16,8 @@ rules: list[Rule] = [
     mapping.MappingRule(),
     disjoint_simulations.DisjointSimulationsRule(),
     provide_mesh.ProvideMeshRule(),
-    coupling_scheme_mapping.CouplingSchemeMappingRule()
+    coupling_scheme_mapping.CouplingSchemeMappingRule(),
+    receive_mesh.ReceiveMeshRule(),
 ]
 
 

--- a/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
+++ b/tests/coupling-scheme-mapping/coupling-scheme-mapping_test.py
@@ -1,8 +1,11 @@
+from precice_config_graph.nodes import ParticipantNode, MeshNode, DataNode, Direction
+
 from preciceconfigchecker.rules.disjoint_simulations import DisjointSimulationsRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as c
 from preciceconfigchecker.rules.mapping import MappingRule as m, MissingDataProcessing as mdp
+from preciceconfigchecker.rules.receive_mesh import ReceiveMeshRule as r
+
 from tests.test_utils import assert_equal_violations, create_graph, get_actual_violations
-from precice_config_graph.nodes import ParticipantNode, MeshNode, DataNode, Direction
 
 
 def test_coupling_scheme_mapping():
@@ -46,7 +49,10 @@ def test_coupling_scheme_mapping():
         d.SharedDataDisjointSimulationsViolation(d_color, frozenset([frozenset([p_generator, p_propagator, p_elevator]),
                                                                      frozenset([p_alligator, p_instigator])])),
         m.JustInTimeMappingMissingDataProcessingViolation(p_alligator, p_instigator, m_instigator, Direction.WRITE,
-                                                          mdp.READ_DATA)
+                                                          mdp.READ_DATA),
+        r.UnusedReceiveMesh(p_generator, m_propagator),
+
+        r.UnusedReceiveMesh(p_propagator, m_generator),
     ]
 
     assert_equal_violations("Coupling-scheme-mapping-test", violations_expected, violations_actual)

--- a/tests/data-rules/use-read-write-not_exchange/use-read-write-not_exchange_test.py
+++ b/tests/data-rules/use-read-write-not_exchange/use-read-write-not_exchange_test.py
@@ -2,12 +2,12 @@ from precice_config_graph.nodes import DataNode, ParticipantNode, MeshNode, Dire
 
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
 from preciceconfigchecker.rules.mapping import MappingRule as m
+from preciceconfigchecker.rules.receive_mesh import ReceiveMeshRule as r
 
 from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph
 
 
 def test_data_not_use_not_read_not_write():
-
     graph = create_graph("tests/data-rules/use-read-write-not_exchange/precice-config.xml")
 
     violations_actual = get_actual_violations(graph)
@@ -27,6 +27,8 @@ def test_data_not_use_not_read_not_write():
                 p_alligator = node
             elif node.name == "Instigator":
                 p_instigator = node
+            elif node.name == "Elevator":
+                p_elevator = node
         elif isinstance(node, MeshNode):
             if node.name == "Generator-Mesh":
                 m_generator = node
@@ -45,9 +47,11 @@ def test_data_not_use_not_read_not_write():
 
                             d.DataNotExchangedViolation(d_color, p_generator, p_instigator),
 
-                            m.MissingExchangeMappingViolation(p_instigator,p_generator, m_generator, Direction.READ),
+                            m.MissingExchangeMappingViolation(p_instigator, p_generator, m_generator, Direction.READ),
 
-                            m.MissingExchangeMappingViolation(p_alligator,p_generator, m_generator, Direction.READ),
+                            m.MissingExchangeMappingViolation(p_alligator, p_generator, m_generator, Direction.READ),
+
+                            r.MappedAPIAccessReceiveMesh(p_elevator, m_generator),
                             ]
 
     assert_equal_violations("Data-not-exchanged-test", violations_expected, violations_actual)

--- a/tests/mapping/mapping_test.py
+++ b/tests/mapping/mapping_test.py
@@ -4,6 +4,7 @@ from preciceconfigchecker.rules.mapping import MappingRule as m, MissingDataProc
 from preciceconfigchecker.rules.m2n_exchange import M2NExchangeRule as mn
 from preciceconfigchecker.rules.data_use_read_write import DataUseReadWriteRule as d
 from preciceconfigchecker.rules.coupling_scheme_mapping import CouplingSchemeMappingRule as csm
+from preciceconfigchecker.rules.receive_mesh import ReceiveMeshRule as r
 
 from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph
 
@@ -87,7 +88,9 @@ def test_mapping():
 
         csm.MissingMappingCouplingSchemeViolation(p_incinerator, p_propagator, m_incinerator, d_color),
 
-        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator, d_color)
+        csm.MissingMappingCouplingSchemeViolation(p_generator, p_propagator, m_generator, d_color),
+
+        r.UnusedReceiveMesh(p_generator,m_propagator),
     ]
 
     assert_equal_violations("Mapping-test", violations_expected, violations_actual)

--- a/tests/provide-mesh/provide-mesh_test.py
+++ b/tests/provide-mesh/provide-mesh_test.py
@@ -4,8 +4,7 @@ from tests.test_utils import assert_equal_violations, get_actual_violations, cre
 from preciceconfigchecker.rules.provide_mesh import ProvideMeshRule as pm
 
 
-def test_simple_good():
-    # tests/provide-mesh/
+def test_provide_mesh():
     graph = create_graph("tests/provide-mesh/precice-config.xml")
 
     violations_actual = get_actual_violations(graph)

--- a/tests/receive-mesh/precice-config.xml
+++ b/tests/receive-mesh/precice-config.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      filter="%Severity% > debug"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:scalar name="Color" />
+
+  <mesh name="Wedding-Gift-Mesh" dimensions="2">
+    <use-data name="Color" />
+  </mesh>
+
+  <mesh name="Generator-Mesh" dimensions="2">
+    <use-data name="Color" />
+  </mesh>
+
+  <mesh name="Propagator-Mesh" dimensions="2">
+    <use-data name="Color" />
+  </mesh>
+
+  <participant name="Generator">
+    <provide-mesh name="Generator-Mesh" />
+    <provide-mesh name="Wedding-Gift-Mesh" />
+    <write-data name="Color" mesh="Generator-Mesh" />
+  </participant>
+
+  <participant name="Propagator">
+    <receive-mesh name="Generator-Mesh" from="Generator" api-access="true" />
+    <receive-mesh name="Wedding-Gift-Mesh" from="Generator" />
+    <provide-mesh name="Propagator-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Generator-Mesh"
+      to="Propagator-Mesh"
+      constraint="consistent" />
+    <read-data name="Color" mesh="Propagator-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".." />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Generator" second="Propagator" />
+    <time-window-size value="0.01" />
+    <max-time value="0.3" />
+    <exchange data="Color" mesh="Generator-Mesh" from="Generator" to="Propagator" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/receive-mesh/receive-mesh_test.py
+++ b/tests/receive-mesh/receive-mesh_test.py
@@ -1,0 +1,26 @@
+from precice_config_graph.nodes import ParticipantNode, MeshNode
+
+from tests.test_utils import assert_equal_violations, get_actual_violations, create_graph
+from preciceconfigchecker.rules.receive_mesh import ReceiveMeshRule as r
+
+
+def test_receive_mesh():
+    graph = create_graph("tests/receive-mesh/precice-config.xml")
+
+    violations_actual = get_actual_violations(graph)
+
+    for node in graph.nodes:
+        if isinstance(node, ParticipantNode):
+            if node.name == "Generator":
+                p_generator = node
+            elif node.name == "Propagator":
+                p_propagator = node
+        elif isinstance(node, MeshNode):
+            if node.name == "Wedding-Gift-Mesh":
+                m_wedding_gift = node
+
+    violations_expected = [
+        r.UnusedReceiveMesh(p_propagator, m_wedding_gift)
+    ]
+
+    assert_equal_violations("Receive-mesh test", violations_expected, violations_actual)

--- a/tests/receive-mesh/receive-mesh_test.py
+++ b/tests/receive-mesh/receive-mesh_test.py
@@ -18,9 +18,13 @@ def test_receive_mesh():
         elif isinstance(node, MeshNode):
             if node.name == "Wedding-Gift-Mesh":
                 m_wedding_gift = node
+            elif node.name == "Generator-Mesh":
+                m_generator = node
 
     violations_expected = [
-        r.UnusedReceiveMesh(p_propagator, m_wedding_gift)
+        r.UnusedReceiveMesh(p_propagator, m_wedding_gift),
+
+        r.MappedAPIAccessReceiveMesh(p_propagator,m_generator),
     ]
 
     assert_equal_violations("Receive-mesh test", violations_expected, violations_actual)


### PR DESCRIPTION
Update 25.5.25:
New in this version is a rule that checks for unused receive meshes!
- A receive-mesh is unused, if a participant receives it (without api-access), but does not map it to their own mesh. 
- It is also unused, if a participant receives it with api-access, but does not operate directly on it.
- Bonus violation: If a participant receives a mesh with api-access, they do not have to map it. If they still do, they get a debug-violation!

Have fun enjoying this new functionality!

Closes #7 